### PR TITLE
Fix cargo fmt

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,9 +37,9 @@ jobs:
           sudo dnf -y update
           sudo dnf -y install dtc libcxx-devel gcc cmake clang
 
-          #- name: Check formatting
-          #  run: |
-          #    cargo +nightly fmt --all -- --check
+      - name: Check formatting
+        run: |
+          cargo +nightly fmt --all -- --check
 
           #- name: Run clippy
           #  run: |

--- a/src/elf_loader.rs
+++ b/src/elf_loader.rs
@@ -1,5 +1,5 @@
-use mmap::{MemoryMap};
 use memmap::Mmap;
+use mmap::MemoryMap;
 use num::traits::FromPrimitive;
 use std::fs::File;
 
@@ -72,49 +72,47 @@ pub enum Phdr_Type {
 
 #[allow(non_camel_case_types)]
 pub enum SectionType {
-    SHT_NULL	       = 0,		/* Section header table entry unused */
-    SHT_PROGBITS	   = 1,		/* Program data */
-    SHT_SYMTAB	       = 2,		/* Symbol table */
-    SHT_STRTAB	       = 3,		/* String table */
-    SHT_RELA	       = 4,		/* Relocation entries with addends */
-    SHT_HASH	       = 5,		/* Symbol hash table */
-    SHT_DYNAMIC	       = 6,		/* Dynamic linking information */
-    SHT_NOTE	       = 7,		/* Notes */
-    SHT_NOBITS	       = 8,		/* Program space with no data (bss) */
-    SHT_REL		       = 9,		/* Relocation entries, no addends */
-    SHT_SHLIB	       = 10,		/* Reserved */
-    SHT_DYNSYM	       = 11,		/* Dynamic linker symbol table */
-    SHT_INIT_ARRAY	   = 14,		/* Array of constructors */
-    SHT_FINI_ARRAY	   = 15,		/* Array of destructors */
-    SHT_PREINIT_ARRAY  = 16,		/* Array of pre-constructors */
-    SHT_GROUP	       = 17	,	/* Section group */
-    SHT_SYMTAB_SHNDX   = 18,		/* Extended section indeces */
-    SHT_NUM		       = 19,		/* Number of defined types.  */
-    SHT_LOOS	       = 0x60000000, 	/* Start OS-specific.  */
-    SHT_GNU_ATTRIBUTES = 0x6ffffff5, 	/* Object attributes.  */
-    SHT_GNU_HASH	   = 0x6ffffff6	, /* GNU-style hash table.  */
-    SHT_GNU_LIBLIST	   = 0x6ffffff7	, /* Prelink library list */
-    SHT_CHECKSUM	   = 0x6ffffff8	, /* Checksum for DSO content.  */
-    SHT_LOSUNW	       = 0x6ffffffa,	/* Sun-specific low bound.  */
+    SHT_NULL = 0,                    /* Section header table entry unused */
+    SHT_PROGBITS = 1,                /* Program data */
+    SHT_SYMTAB = 2,                  /* Symbol table */
+    SHT_STRTAB = 3,                  /* String table */
+    SHT_RELA = 4,                    /* Relocation entries with addends */
+    SHT_HASH = 5,                    /* Symbol hash table */
+    SHT_DYNAMIC = 6,                 /* Dynamic linking information */
+    SHT_NOTE = 7,                    /* Notes */
+    SHT_NOBITS = 8,                  /* Program space with no data (bss) */
+    SHT_REL = 9,                     /* Relocation entries, no addends */
+    SHT_SHLIB = 10,                  /* Reserved */
+    SHT_DYNSYM = 11,                 /* Dynamic linker symbol table */
+    SHT_INIT_ARRAY = 14,             /* Array of constructors */
+    SHT_FINI_ARRAY = 15,             /* Array of destructors */
+    SHT_PREINIT_ARRAY = 16,          /* Array of pre-constructors */
+    SHT_GROUP = 17,                  /* Section group */
+    SHT_SYMTAB_SHNDX = 18,           /* Extended section indeces */
+    SHT_NUM = 19,                    /* Number of defined types.  */
+    SHT_LOOS = 0x60000000,           /* Start OS-specific.  */
+    SHT_GNU_ATTRIBUTES = 0x6ffffff5, /* Object attributes.  */
+    SHT_GNU_HASH = 0x6ffffff6,       /* GNU-style hash table.  */
+    SHT_GNU_LIBLIST = 0x6ffffff7,    /* Prelink library list */
+    SHT_CHECKSUM = 0x6ffffff8,       /* Checksum for DSO content.  */
+    SHT_LOSUNW = 0x6ffffffa,         /* Sun-specific low bound.  */
     // SHT_SUNW_move	  = 0x6ffffffa,
-    SHT_SUNW_COMDAT    = 0x6ffffffb,
-    SHT_SUNW_syminfo   = 0x6ffffffc,
-    SHT_GNU_verdef	   = 0x6ffffffd,	/* Version definition section.  */
-    SHT_GNU_verneed	   = 0x6ffffffe,	/* Version needs section.  */
-    SHT_GNU_versym	   = 0x6fffffff,	/* Version symbol table.  */
+    SHT_SUNW_COMDAT = 0x6ffffffb,
+    SHT_SUNW_syminfo = 0x6ffffffc,
+    SHT_GNU_verdef = 0x6ffffffd,  /* Version definition section.  */
+    SHT_GNU_verneed = 0x6ffffffe, /* Version needs section.  */
+    SHT_GNU_versym = 0x6fffffff,  /* Version symbol table.  */
     // SHT_HISUNW	 = 0x6fffffff,	/* Sun-specific high bound.  */
     // SHT_HIOS	       = 0x6fffffff,	/* End OS-specific type */
-    SHT_LOPROC	       = 0x70000000,	/* Start of processor-specific */
-    SHT_HIPROC	       = 0x7fffffff,	/* End of processor-specific */
-    SHT_LOUSER	       = 0x80000000,	/* Start of application-specific */
-    SHT_HIUSER	       = 0x8fffffff,	/* End of application-specific */
+    SHT_LOPROC = 0x70000000, /* Start of processor-specific */
+    SHT_HIPROC = 0x7fffffff, /* End of processor-specific */
+    SHT_LOUSER = 0x80000000, /* Start of application-specific */
+    SHT_HIUSER = 0x8fffffff, /* End of application-specific */
 }
-
 
 #[allow(non_camel_case_types)]
 pub enum SectionFlags {
     SHF_WRITE = 1 << 0,
-
 }
 
 impl FromPrimitive for Phdr_Type {
@@ -549,14 +547,31 @@ impl ELFLoader {
         )
     }
 
-    pub fn load_section(&self, offset: usize, memory: &mut MemoryMap, sh_offset: u64, sh_start: u64, sh_memsz: u64) {
-        println!("load_section() sh_offset = {:08x}, sh_memsz = {:08x}", sh_offset, sh_memsz);
+    pub fn load_section(
+        &self,
+        offset: usize,
+        memory: &mut MemoryMap,
+        sh_offset: u64,
+        sh_start: u64,
+        sh_memsz: u64,
+    ) {
+        println!(
+            "load_section() sh_offset = {:08x}, sh_memsz = {:08x}",
+            sh_offset, sh_memsz
+        );
         for idx in 0..sh_memsz {
             let offset_idx = sh_offset + idx;
             let inst_byte: u8 = self.get_1byte_elf(offset_idx as usize);
-            unsafe { memory.data().offset(sh_start.wrapping_sub(offset as u64).wrapping_add(idx as u64) as isize).write(inst_byte) };
+            unsafe {
+                memory
+                    .data()
+                    .offset(
+                        sh_start
+                            .wrapping_sub(offset as u64)
+                            .wrapping_add(idx as u64) as isize,
+                    )
+                    .write(inst_byte)
+            };
         }
     }
-
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,29 +3,29 @@ use std::{env, process};
 pub mod elf_loader;
 pub mod emu_env;
 pub mod instr_info;
-pub mod target;
-pub mod tcg;
 pub mod op_helper;
+pub mod op_helper_fcvt;
 pub mod op_helper_fp_d;
 pub mod op_helper_fp_s;
 pub mod op_helper_mem;
-pub mod op_helper_fcvt;
+pub mod target;
+pub mod tcg;
 
 use emu_env::MachineEnum;
 
-use crate::emu_env::{EmuEnv, ArgConfig};
+use crate::emu_env::{ArgConfig, EmuEnv};
 
 pub fn run(filename: String, step: bool, exp_gpr: &[u64; 32]) -> usize {
     let arg_config = ArgConfig {
-        step    : step,
-        debug   : false,
+        step: step,
+        debug: false,
         dump_gpr: false,
         dump_fpr: false,
         dump_tcg: false,
         mmu_debug: false,
         dump_guest: false,
         dump_host: false,
-        machine : MachineEnum::RiscvVirt,
+        machine: MachineEnum::RiscvVirt,
         opt_reg_fwd: false,
         elf_file: filename.clone(),
     };
@@ -44,23 +44,23 @@ pub fn run(filename: String, step: bool, exp_gpr: &[u64; 32]) -> usize {
 
 pub fn run_riscv_test(filename: String, opt_step: bool) -> u64 {
     let riscv_path = match env::var("RISCV") {
-            Ok(val) => val,
-            Err(err) => {
-                println!("{}: RISCV", err);
-                process::exit(1);
-            },
-        };
+        Ok(val) => val,
+        Err(err) => {
+            println!("{}: RISCV", err);
+            process::exit(1);
+        }
+    };
 
     let arg_config = ArgConfig {
-        step    : opt_step,
-        debug   : false,
+        step: opt_step,
+        debug: false,
         dump_gpr: false,
         dump_fpr: false,
         dump_tcg: false,
-        mmu_debug : false,
+        mmu_debug: false,
         dump_guest: false,
         dump_host: false,
-        machine : MachineEnum::RiscvVirt,
+        machine: MachineEnum::RiscvVirt,
         opt_reg_fwd: false,
         elf_file: riscv_path + &filename,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,6 @@ use crate::emu_env::ArgConfig;
 use crate::emu_env::EmuEnv;
 
 fn main() {
-
     let mut cfg = ArgConfig::parse();
     if cfg.dump_gpr || cfg.dump_fpr || cfg.dump_tcg {
         cfg.debug = true;

--- a/src/op_helper_fcvt.rs
+++ b/src/op_helper_fcvt.rs
@@ -1,7 +1,7 @@
-use softfloat_wrapper::{ExceptionFlags, Float, F64, F32, RoundingMode};
-use crate::target::riscv::riscv_csr::{CsrAddr};
-use crate::target::riscv::riscv::CallFcvtIdx;
 use crate::emu_env::EmuEnv;
+use crate::target::riscv::riscv::CallFcvtIdx;
+use crate::target::riscv::riscv_csr::CsrAddr;
+use softfloat_wrapper::{ExceptionFlags, Float, RoundingMode, F32, F64};
 
 impl EmuEnv {
     pub fn helper_func_fcvt(emu: &mut EmuEnv, call_idx: u64, rd: u64, rs1: u64, _: u64) -> usize {
@@ -9,24 +9,96 @@ impl EmuEnv {
         flag.set();
         let helper_idx = CallFcvtIdx::from_u64(call_idx);
         match helper_idx {
-            CallFcvtIdx::W_S  => { let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32).to_i32(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as u64; },
-            CallFcvtIdx::WU_S => { let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32).to_u32(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as i32 as u64; },
-            CallFcvtIdx::S_W  => { let to_data = F32::from_i32 (emu.m_iregs[rs1 as usize] as i32, RoundingMode::TowardZero)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::S_WU => { let to_data = F32::from_u32 (emu.m_iregs[rs1 as usize] as u32, RoundingMode::TiesToEven)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::S_D  => { let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64).to_f32(RoundingMode::TowardZero); emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::D_S  => { let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32).to_f64(RoundingMode::TowardZero); emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::W_D  => { let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64).to_i32(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as u64; },
-            CallFcvtIdx::WU_D => { let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64).to_u32(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as i32 as u64; },
-            CallFcvtIdx::D_W  => { let to_data = F64::from_i32 (emu.m_iregs[rs1 as usize] as i32, RoundingMode::TowardZero)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::D_WU => { let to_data = F64::from_u32 (emu.m_iregs[rs1 as usize] as u32, RoundingMode::TowardZero)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::L_S  => { let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32).to_i64(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as u64; },
-            CallFcvtIdx::LU_S => { let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32).to_u64(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as u64; },
-            CallFcvtIdx::S_L  => { let to_data = F32::from_i64 (emu.m_iregs[rs1 as usize] as i64, RoundingMode::TowardZero)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::S_LU => { let to_data = F32::from_u64 (emu.m_iregs[rs1 as usize] as u64, RoundingMode::TiesToEven)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::L_D  => { let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64).to_i64(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as u64; },
-            CallFcvtIdx::LU_D => { let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64).to_u64(RoundingMode::TowardZero, true); emu.m_iregs[rd as usize] = to_data        as u64; },
-            CallFcvtIdx::D_L  => { let to_data = F64::from_i64 (emu.m_iregs[rs1 as usize] as i64, RoundingMode::TowardZero)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
-            CallFcvtIdx::D_LU => { let to_data = F64::from_u64 (emu.m_iregs[rs1 as usize] as u64, RoundingMode::TiesToEven)     ; emu.m_fregs[rd as usize] = to_data.bits() as u64; },
+            CallFcvtIdx::W_S => {
+                let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32)
+                    .to_i32(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as u64;
+            }
+            CallFcvtIdx::WU_S => {
+                let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32)
+                    .to_u32(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as i32 as u64;
+            }
+            CallFcvtIdx::S_W => {
+                let to_data =
+                    F32::from_i32(emu.m_iregs[rs1 as usize] as i32, RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::S_WU => {
+                let to_data =
+                    F32::from_u32(emu.m_iregs[rs1 as usize] as u32, RoundingMode::TiesToEven);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::S_D => {
+                let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64)
+                    .to_f32(RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::D_S => {
+                let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32)
+                    .to_f64(RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::W_D => {
+                let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64)
+                    .to_i32(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as u64;
+            }
+            CallFcvtIdx::WU_D => {
+                let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64)
+                    .to_u32(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as i32 as u64;
+            }
+            CallFcvtIdx::D_W => {
+                let to_data =
+                    F64::from_i32(emu.m_iregs[rs1 as usize] as i32, RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::D_WU => {
+                let to_data =
+                    F64::from_u32(emu.m_iregs[rs1 as usize] as u32, RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::L_S => {
+                let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32)
+                    .to_i64(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as u64;
+            }
+            CallFcvtIdx::LU_S => {
+                let to_data = F32::from_bits(emu.m_fregs[rs1 as usize] as u32)
+                    .to_u64(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as u64;
+            }
+            CallFcvtIdx::S_L => {
+                let to_data =
+                    F32::from_i64(emu.m_iregs[rs1 as usize] as i64, RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::S_LU => {
+                let to_data =
+                    F32::from_u64(emu.m_iregs[rs1 as usize] as u64, RoundingMode::TiesToEven);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::L_D => {
+                let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64)
+                    .to_i64(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as u64;
+            }
+            CallFcvtIdx::LU_D => {
+                let to_data = F64::from_bits(emu.m_fregs[rs1 as usize] as u64)
+                    .to_u64(RoundingMode::TowardZero, true);
+                emu.m_iregs[rd as usize] = to_data as u64;
+            }
+            CallFcvtIdx::D_L => {
+                let to_data =
+                    F64::from_i64(emu.m_iregs[rs1 as usize] as i64, RoundingMode::TowardZero);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
+            CallFcvtIdx::D_LU => {
+                let to_data =
+                    F64::from_u64(emu.m_iregs[rs1 as usize] as u64, RoundingMode::TiesToEven);
+                emu.m_fregs[rd as usize] = to_data.bits() as u64;
+            }
         };
 
         flag.get();

--- a/src/op_helper_fp_d.rs
+++ b/src/op_helper_fp_d.rs
@@ -1,6 +1,6 @@
-use softfloat_wrapper::{ExceptionFlags, Float, RoundingMode, F64};
-use crate::target::riscv::riscv_csr::{CsrAddr};
 use crate::emu_env::EmuEnv;
+use crate::target::riscv::riscv_csr::CsrAddr;
+use softfloat_wrapper::{ExceptionFlags, Float, RoundingMode, F64};
 
 impl EmuEnv {
     pub fn helper_func_fadd_d(emu: &mut EmuEnv, fd: u64, fs1: u64, fs2: u64, _: u64) -> usize {
@@ -185,7 +185,10 @@ impl EmuEnv {
         emu.m_iregs[rd as usize] = fs1_data.eq(fs2_data) as u64;
         flag.get();
         let ret_flag = flag.bits();
-        println!("feq(emu, {:}, {:}, {:}) => {:} is called!", rd, fs1, fs2, ret_flag);
+        println!(
+            "feq(emu, {:}, {:}, {:}) => {:} is called!",
+            rd, fs1, fs2, ret_flag
+        );
         emu.m_csr.csrrw(CsrAddr::FFlags, ret_flag as i64);
         return 0;
     }
@@ -198,7 +201,10 @@ impl EmuEnv {
         emu.m_iregs[rd as usize] = fs1_data.lt(fs2_data) as u64;
         flag.get();
         let ret_flag = flag.bits();
-        println!("flt(emu, {:}, {:}, {:}) is called! => {:}", rd, fs1, fs2, ret_flag);
+        println!(
+            "flt(emu, {:}, {:}, {:}) is called! => {:}",
+            rd, fs1, fs2, ret_flag
+        );
         emu.m_csr.csrrw(CsrAddr::FFlags, ret_flag as i64);
         return 0;
     }
@@ -222,20 +228,21 @@ impl EmuEnv {
         #[allow(unused_assignments)]
         let mut result = 0;
         if fs1_data.is_negative_infinity() {
-            result= 1 << 0;
+            result = 1 << 0;
         } else if fs1_data.is_positive_infinity() {
-            result= 1 << 7;
+            result = 1 << 7;
         } else if fs1_data.is_negative_zero() {
-            result= 1 << 3;
+            result = 1 << 3;
         } else if fs1_data.is_positive_zero() {
-            result= 1 << 4;
-        } else if fs1_data.is_negative_zero() || fs1_data.is_negative_subnormal(){
+            result = 1 << 4;
+        } else if fs1_data.is_negative_zero() || fs1_data.is_negative_subnormal() {
             result = 1 << 2;
-        } else if fs1_data.is_positive_zero () || fs1_data.is_positive_subnormal() {
+        } else if fs1_data.is_positive_zero() || fs1_data.is_positive_subnormal() {
             result = 1 << 5;
         } else if fs1_data.is_nan() {
-            if (fs1_data.exponent() == F64::EXPONENT_BIT) &&
-                (fs1_data.fraction() & (1 << (F64::EXPONENT_POS - 1))) != 0 {
+            if (fs1_data.exponent() == F64::EXPONENT_BIT)
+                && (fs1_data.fraction() & (1 << (F64::EXPONENT_POS - 1))) != 0
+            {
                 result = 1 << 9;
             } else {
                 result = 1 << 8;
@@ -254,17 +261,22 @@ impl EmuEnv {
         let fs2_data = F64::from_bits(emu.m_fregs[fs2 as usize]);
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = 
-        if fs1_data.is_nan() && fs2_data.is_nan() { 
+        emu.m_fregs[rd as usize] = if fs1_data.is_nan() && fs2_data.is_nan() {
             F64::quiet_nan().bits() as u64
-        } else if fs2_data.lt_quiet(fs1_data) || fs2_data.is_nan() || fs1_data.eq(fs2_data) && fs2_data.is_negative() {
+        } else if fs2_data.lt_quiet(fs1_data)
+            || fs2_data.is_nan()
+            || fs1_data.eq(fs2_data) && fs2_data.is_negative()
+        {
             fs1_data.bits() as u64
         } else {
             fs2_data.bits() as u64
         };
         flag.get();
         let ret_flag = flag.bits();
-        println!("fmax_d(emu, {:}, {:}, {:}) is called! => {:}", rd, fs1, fs2, ret_flag);
+        println!(
+            "fmax_d(emu, {:}, {:}, {:}) is called! => {:}",
+            rd, fs1, fs2, ret_flag
+        );
         emu.m_csr.csrrw(CsrAddr::FFlags, ret_flag as i64);
         return 0;
     }
@@ -274,10 +286,12 @@ impl EmuEnv {
         let fs2_data = F64::from_bits(emu.m_fregs[fs2 as usize]);
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = 
-        if fs1_data.is_nan() && fs2_data.is_nan() { 
+        emu.m_fregs[rd as usize] = if fs1_data.is_nan() && fs2_data.is_nan() {
             F64::quiet_nan().bits() as u64
-        } else if fs1_data.lt_quiet(fs2_data) || fs2_data.is_nan() || fs1_data.eq(fs2_data) && fs1_data.is_negative() {
+        } else if fs1_data.lt_quiet(fs2_data)
+            || fs2_data.is_nan()
+            || fs1_data.eq(fs2_data) && fs1_data.is_negative()
+        {
             fs1_data.bits() as u64
         } else {
             fs2_data.bits() as u64

--- a/src/op_helper_fp_s.rs
+++ b/src/op_helper_fp_s.rs
@@ -1,10 +1,10 @@
-use softfloat_wrapper::{ExceptionFlags, Float, RoundingMode, F32};
-use crate::target::riscv::riscv_csr::{CsrAddr};
 use crate::emu_env::EmuEnv;
+use crate::target::riscv::riscv_csr::CsrAddr;
+use softfloat_wrapper::{ExceptionFlags, Float, RoundingMode, F32};
 
 impl EmuEnv {
     #[inline]
-    fn convert_nan_boxing (i: u64) -> u32 {
+    fn convert_nan_boxing(i: u64) -> u32 {
         if i & 0xffffffff_00000000 == 0xffffffff_00000000 {
             (i & 0xffffffff) as u32
         } else {
@@ -195,7 +195,10 @@ impl EmuEnv {
         emu.m_iregs[rd as usize] = fs1_data.eq(fs2_data) as u64;
         flag.get();
         let ret_flag = flag.bits();
-        println!("feq(emu, {:}, {:}, {:}) => {:} is called!", rd, fs1, fs2, ret_flag);
+        println!(
+            "feq(emu, {:}, {:}, {:}) => {:} is called!",
+            rd, fs1, fs2, ret_flag
+        );
         emu.m_csr.csrrw(CsrAddr::FFlags, ret_flag as i64);
         return 0;
     }
@@ -208,7 +211,10 @@ impl EmuEnv {
         emu.m_iregs[rd as usize] = fs1_data.lt(fs2_data) as u64;
         flag.get();
         let ret_flag = flag.bits();
-        println!("flt(emu, {:}, {:}, {:}) is called! => {:}", rd, fs1, fs2, ret_flag);
+        println!(
+            "flt(emu, {:}, {:}, {:}) is called! => {:}",
+            rd, fs1, fs2, ret_flag
+        );
         emu.m_csr.csrrw(CsrAddr::FFlags, ret_flag as i64);
         return 0;
     }
@@ -232,20 +238,21 @@ impl EmuEnv {
         #[allow(unused_assignments)]
         let mut result = 0;
         if fs1_data.is_negative_infinity() {
-            result= 1 << 0;
+            result = 1 << 0;
         } else if fs1_data.is_positive_infinity() {
-            result= 1 << 7;
+            result = 1 << 7;
         } else if fs1_data.is_negative_zero() {
-            result= 1 << 3;
+            result = 1 << 3;
         } else if fs1_data.is_positive_zero() {
-            result= 1 << 4;
-        } else if fs1_data.is_negative_zero() || fs1_data.is_negative_subnormal(){
+            result = 1 << 4;
+        } else if fs1_data.is_negative_zero() || fs1_data.is_negative_subnormal() {
             result = 1 << 2;
-        } else if fs1_data.is_positive_zero () || fs1_data.is_positive_subnormal() {
+        } else if fs1_data.is_positive_zero() || fs1_data.is_positive_subnormal() {
             result = 1 << 5;
         } else if fs1_data.is_nan() {
-            if (fs1_data.exponent() == F32::EXPONENT_BIT) &&
-                (fs1_data.fraction() & (1 << (F32::EXPONENT_POS - 1))) != 0 {
+            if (fs1_data.exponent() == F32::EXPONENT_BIT)
+                && (fs1_data.fraction() & (1 << (F32::EXPONENT_POS - 1))) != 0
+            {
                 result = 1 << 9;
             } else {
                 result = 1 << 8;
@@ -264,17 +271,22 @@ impl EmuEnv {
         let fs2_data = F32::from_bits(emu.m_fregs[fs2 as usize] as u32);
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = 
-        if fs1_data.is_nan() && fs2_data.is_nan() { 
+        emu.m_fregs[rd as usize] = if fs1_data.is_nan() && fs2_data.is_nan() {
             F32::quiet_nan().bits() as u64
-        } else if fs2_data.lt_quiet(fs1_data) || fs2_data.is_nan() || fs1_data.eq(fs2_data) && fs2_data.is_negative() {
+        } else if fs2_data.lt_quiet(fs1_data)
+            || fs2_data.is_nan()
+            || fs1_data.eq(fs2_data) && fs2_data.is_negative()
+        {
             fs1_data.bits() as u64
         } else {
             fs2_data.bits() as u64
         };
         flag.get();
         let ret_flag = flag.bits();
-        println!("fmax_d(emu, {:}, {:}, {:}) is called! => {:}", rd, fs1, fs2, ret_flag);
+        println!(
+            "fmax_d(emu, {:}, {:}, {:}) is called! => {:}",
+            rd, fs1, fs2, ret_flag
+        );
         emu.m_csr.csrrw(CsrAddr::FFlags, ret_flag as i64);
         return 0;
     }
@@ -284,10 +296,12 @@ impl EmuEnv {
         let fs2_data = F32::from_bits(emu.m_fregs[fs2 as usize] as u32);
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = 
-        if fs1_data.is_nan() && fs2_data.is_nan() { 
+        emu.m_fregs[rd as usize] = if fs1_data.is_nan() && fs2_data.is_nan() {
             F32::quiet_nan().bits() as u64
-        } else if fs1_data.lt_quiet(fs2_data) || fs2_data.is_nan() || fs1_data.eq(fs2_data) && fs1_data.is_negative() {
+        } else if fs1_data.lt_quiet(fs2_data)
+            || fs2_data.is_nan()
+            || fs1_data.eq(fs2_data) && fs1_data.is_negative()
+        {
             fs1_data.bits() as u64
         } else {
             fs2_data.bits() as u64
@@ -304,7 +318,8 @@ impl EmuEnv {
         let fs2_data = Self::convert_nan_boxing(emu.m_fregs[fs2 as usize]) as u32;
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = (fs1_data & 0x7fffffff | fs2_data & 0x80000000) as u64 | 0xffffffff_00000000;
+        emu.m_fregs[rd as usize] =
+            (fs1_data & 0x7fffffff | fs2_data & 0x80000000) as u64 | 0xffffffff_00000000;
         flag.get();
         let ret_flag = flag.bits();
         println!("fsgnj_s(emu, {:}, {:}, {:}) is called!", rd, fs1, fs2);
@@ -317,7 +332,8 @@ impl EmuEnv {
         let fs2_data = Self::convert_nan_boxing(emu.m_fregs[fs2 as usize]) as u32;
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = (fs1_data & 0x7fffffff | !fs2_data & 0x80000000) as u64 | 0xffffffff_00000000;
+        emu.m_fregs[rd as usize] =
+            (fs1_data & 0x7fffffff | !fs2_data & 0x80000000) as u64 | 0xffffffff_00000000;
         flag.get();
         let ret_flag = flag.bits();
         println!("fsgnjn_s(emu, {:}, {:}, {:}) is called!", rd, fs1, fs2);
@@ -325,13 +341,14 @@ impl EmuEnv {
         return 0;
     }
 
-
     pub fn helper_func_fsgnjx_s(emu: &mut EmuEnv, rd: u64, fs1: u64, fs2: u64, _: u64) -> usize {
         let fs1_data = Self::convert_nan_boxing(emu.m_fregs[fs1 as usize]) as u32;
         let fs2_data = Self::convert_nan_boxing(emu.m_fregs[fs2 as usize]) as u32;
         let mut flag = ExceptionFlags::default();
         flag.set();
-        emu.m_fregs[rd as usize] = (fs1_data & 0x7fffffff | (fs1_data ^ fs2_data) & 0x80000000) as u64 | 0xffffffff_00000000;
+        emu.m_fregs[rd as usize] = (fs1_data & 0x7fffffff | (fs1_data ^ fs2_data) & 0x80000000)
+            as u64
+            | 0xffffffff_00000000;
         flag.get();
         let ret_flag = flag.bits();
         println!("fsgnjx_s(emu, {:}, {:}, {:}) is called!", rd, fs1, fs2);

--- a/src/op_helper_mem.rs
+++ b/src/op_helper_mem.rs
@@ -3,19 +3,33 @@ use crate::target::riscv::mmu::{MemAccType, MemResult};
 use crate::target::riscv::riscv::ExceptCode;
 
 impl EmuEnv {
-    pub fn helper_func_load64(emu: &mut EmuEnv,rd: u64,rs1: u64,imm: u64,guest_pc: u64) -> usize {
+    pub fn helper_func_load64(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 // Update TLB List
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 emu.m_iregs[rd as usize] = emu.read_mem_8byte(guest_phy_addr) as u64;
                 return MemResult::NoExcept as usize;
@@ -27,35 +41,58 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_load32(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_load32(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("load32 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "load32 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
-                if emu.m_arg_config.machine == MachineEnum::RiscvSiFiveU && (guest_phy_addr & !0xfff) == 0x1001_0000 {
+                if emu.m_arg_config.machine == MachineEnum::RiscvSiFiveU
+                    && (guest_phy_addr & !0xfff) == 0x1001_0000
+                {
                     if emu.m_arg_config.debug {
                         println!("UART Access : {:08x}", guest_phy_addr);
                     }
                     // region : 0x1000_0000 - 0x1000_0fff
                     match guest_phy_addr {
-                        0x1001_0000 => { emu.m_iregs[rd as usize] = 0; },       // txdata
-                        0x1001_0004 => { emu.m_iregs[rd as usize] = 0; },       // rxdata
-                        0x1001_0008 => { emu.m_iregs[rd as usize] = 0; },       // txctrl
-                        0x1001_000c => { emu.m_iregs[rd as usize] = 0; },       // rxctrl
-                        _ => {},
-                    }                  
+                        0x1001_0000 => {
+                            emu.m_iregs[rd as usize] = 0;
+                        } // txdata
+                        0x1001_0004 => {
+                            emu.m_iregs[rd as usize] = 0;
+                        } // rxdata
+                        0x1001_0008 => {
+                            emu.m_iregs[rd as usize] = 0;
+                        } // txctrl
+                        0x1001_000c => {
+                            emu.m_iregs[rd as usize] = 0;
+                        } // rxctrl
+                        _ => {}
+                    }
                     return MemResult::NoExcept as usize;
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.m_iregs[rd as usize] = emu.read_mem_4byte(guest_phy_addr) as i32 as u64; 
+                emu.m_iregs[rd as usize] = emu.read_mem_4byte(guest_phy_addr) as i32 as u64;
                 return MemResult::NoExcept as usize;
             }
             Err(error) => {
@@ -66,21 +103,34 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_load16(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_load16(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("load16 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "load16 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.m_iregs[rd as usize] = emu.read_mem_2byte(guest_phy_addr) as i16 as u64; 
+                emu.m_iregs[rd as usize] = emu.read_mem_2byte(guest_phy_addr) as i16 as u64;
                 return MemResult::NoExcept as usize;
             }
             Err(error) => {
@@ -91,21 +141,34 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_load8(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_load8(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("load8 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "load8 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.m_iregs[rd as usize] = emu.read_mem_1byte(guest_phy_addr) as i8 as u64; 
+                emu.m_iregs[rd as usize] = emu.read_mem_1byte(guest_phy_addr) as i8 as u64;
                 return MemResult::NoExcept as usize;
             }
             Err(error) => {
@@ -116,21 +179,34 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_loadu32(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_loadu32(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("loadu32 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "loadu32 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.m_iregs[rd as usize] = emu.read_mem_4byte(guest_phy_addr) as u64; 
+                emu.m_iregs[rd as usize] = emu.read_mem_4byte(guest_phy_addr) as u64;
                 return MemResult::NoExcept as usize;
             }
             Err(error) => {
@@ -141,19 +217,32 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_loadu16(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_loadu16(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("loadu16 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "loadu16 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 emu.m_iregs[rd as usize] = emu.read_mem_2byte(guest_phy_addr) as u64;
                 return MemResult::NoExcept as usize;
@@ -166,21 +255,34 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_loadu8(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_loadu8(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("loadu8 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "loadu8 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.m_iregs[rd as usize] = emu.read_mem_1byte(guest_phy_addr) as u64; 
+                emu.m_iregs[rd as usize] = emu.read_mem_1byte(guest_phy_addr) as u64;
                 return MemResult::NoExcept as usize;
             }
             Err(error) => {
@@ -203,17 +305,24 @@ impl EmuEnv {
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Write) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("store64 : converted address: {:016x} --> {:016x} <= {:016x}", addr, guest_phy_addr, rs2_data);
+                    println!(
+                        "store64 : converted address: {:016x} --> {:016x} <= {:016x}",
+                        addr, guest_phy_addr, rs2_data
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.write_mem_8byte(guest_phy_addr, rs2_data); 
-                return MemResult::NoExcept as usize; 
+                emu.write_mem_8byte(guest_phy_addr, rs2_data);
+                return MemResult::NoExcept as usize;
             }
             Err(error) => {
                 print!("Read Error: {:?}\n", error);
@@ -223,38 +332,57 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_store32(emu: &mut EmuEnv, rs2: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_store32(
+        emu: &mut EmuEnv,
+        rs2: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let rs2_data = emu.m_iregs[rs2 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Write) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("store32 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "store32 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
-                if emu.m_arg_config.machine == MachineEnum::RiscvSiFiveU && (guest_phy_addr & !0xfff) == 0x1001_0000 {
+                if emu.m_arg_config.machine == MachineEnum::RiscvSiFiveU
+                    && (guest_phy_addr & !0xfff) == 0x1001_0000
+                {
                     if emu.m_arg_config.debug {
                         println!("UART Access : {:08x}", guest_phy_addr);
                     }
                     // region : 0x1000_0000 - 0x1000_0fff
                     match guest_phy_addr {
-                        0x1001_0000 => { eprint!("{}", (rs2_data & 0xff) as u8 as char) },       // txdata
-                        0x1001_0004 => { },       // rxdata
-                        0x1001_0008 => { },       // txctrl
-                        0x1001_000c => { },       // rxctrl
-                        _ => {},
-                    }                  
+                        0x1001_0000 => {
+                            eprint!("{}", (rs2_data & 0xff) as u8 as char)
+                        } // txdata
+                        0x1001_0004 => {} // rxdata
+                        0x1001_0008 => {} // txctrl
+                        0x1001_000c => {} // rxctrl
+                        _ => {}
+                    }
                     return MemResult::NoExcept as usize;
                 }
-                if emu.m_arg_config.machine == MachineEnum::RiscvSiFiveU && (guest_phy_addr & !0xfff) == 0x10_0000 {
+                if emu.m_arg_config.machine == MachineEnum::RiscvSiFiveU
+                    && (guest_phy_addr & !0xfff) == 0x10_0000
+                {
                     emu.m_notify_exit = true;
                     return MemResult::NoExcept as usize;
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 emu.write_mem_4byte(guest_phy_addr, rs2_data as u32);
                 return MemResult::NoExcept as usize;
@@ -279,14 +407,21 @@ impl EmuEnv {
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Write) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("store16 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "store16 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 emu.write_mem_2byte(guest_phy_addr, rs2_data as u16);
                 return MemResult::NoExcept as usize;
@@ -311,14 +446,21 @@ impl EmuEnv {
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Write) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("store8 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "store8 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 emu.write_mem_1byte(guest_phy_addr, rs2_data as u8);
                 return MemResult::NoExcept as usize;
@@ -331,19 +473,32 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_float_load64(emu: &mut EmuEnv,rd: u64,rs1: u64,imm: u64,guest_pc: u64) -> usize {
+    pub fn helper_func_float_load64(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("loadf64 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "loadf64 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
                 emu.m_fregs[rd as usize] = emu.read_mem_8byte(guest_phy_addr) as u64;
                 return MemResult::NoExcept as usize;
@@ -355,21 +510,35 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_float_load32(emu: &mut EmuEnv, rd: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_float_load32(
+        emu: &mut EmuEnv,
+        rd: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Read) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("loadf32 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "loadf32 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
                 if emu.m_arg_config.mmu_debug {
-                    println!("update tlb_vec[{:}] = {:016x}", ((addr >> 12) & 0xfff) as usize, addr >> (12 + 12));
+                    println!(
+                        "update tlb_vec[{:}] = {:016x}",
+                        ((addr >> 12) & 0xfff) as usize,
+                        addr >> (12 + 12)
+                    );
                 }
-                emu.m_fregs[rd as usize] = emu.read_mem_4byte(guest_phy_addr) as u64 | 0xffffffff00000000;  // NaN Boxing 
+                emu.m_fregs[rd as usize] =
+                    emu.read_mem_4byte(guest_phy_addr) as u64 | 0xffffffff00000000; // NaN Boxing
                 return MemResult::NoExcept as usize;
             }
             Err(error) => {
@@ -380,20 +549,29 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_float_store64(emu: &mut EmuEnv, rs2: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_float_store64(
+        emu: &mut EmuEnv,
+        rs2: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let rs2_data = emu.m_fregs[rs2 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Write) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("storef64 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "storef64 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
-                emu.write_mem_8byte(guest_phy_addr, rs2_data); 
-                return MemResult::NoExcept as usize; 
+                emu.write_mem_8byte(guest_phy_addr, rs2_data);
+                return MemResult::NoExcept as usize;
             }
             Err(error) => {
                 print!("Read Error: {:?}\n", error);
@@ -403,15 +581,24 @@ impl EmuEnv {
         };
     }
 
-    pub fn helper_func_float_store32(emu: &mut EmuEnv, rs2: u64, rs1: u64, imm: u64, guest_pc: u64) -> usize {
+    pub fn helper_func_float_store32(
+        emu: &mut EmuEnv,
+        rs2: u64,
+        rs1: u64,
+        imm: u64,
+        guest_pc: u64,
+    ) -> usize {
         let rs1_data = emu.m_iregs[rs1 as usize];
         let rs2_data = emu.m_fregs[rs2 as usize];
         let addr = rs1_data.wrapping_add(imm as i32 as u64);
 
         match emu.convert_physical_address(guest_pc, addr, MemAccType::Write) {
-            Ok(guest_phy_addr) => { 
+            Ok(guest_phy_addr) => {
                 if emu.m_arg_config.mmu_debug {
-                    println!("storef32 : converted address: {:016x} --> {:016x}", addr, guest_phy_addr);
+                    println!(
+                        "storef32 : converted address: {:016x} --> {:016x}",
+                        addr, guest_phy_addr
+                    );
                 }
                 emu.m_tlb_vec[((addr >> 12) & 0xfff) as usize] = addr >> (12 + 12);
                 emu.m_tlb_addr_vec[((addr >> 12) & 0xfff) as usize] = guest_phy_addr & !0xfff;
@@ -425,5 +612,4 @@ impl EmuEnv {
             }
         };
     }
-
 }

--- a/src/target/riscv/mod.rs
+++ b/src/target/riscv/mod.rs
@@ -1,13 +1,13 @@
 #[macro_use]
 pub mod riscv;
+pub mod mmu;
 pub mod riscv_csr;
 pub mod riscv_csr_def;
 pub mod riscv_decoder;
 pub mod riscv_decoder_extra;
-pub mod riscv_inst_id;
 pub mod riscv_disassemble;
-pub mod mmu;
+pub mod riscv_inst_id;
+mod translate_riscv_c;
+mod translate_riscv_fp;
 mod translate_riscv_int;
 mod translate_riscv_priv;
-mod translate_riscv_fp;
-mod translate_riscv_c;

--- a/src/target/riscv/riscv.rs
+++ b/src/target/riscv/riscv.rs
@@ -1,7 +1,7 @@
 use super::super::super::tcg::tcg::{TCGLabel, TCGOp, TCGOpcode, TCGv};
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::collections::VecDeque;
+use std::rc::Rc;
 
 use super::super::super::instr_info::InstrInfo;
 use super::riscv_inst_id::RiscvInstId;
@@ -73,14 +73,14 @@ pub enum CALL_HELPER_IDX {
     CALL_LOAD64_IDX = 42,
     CALL_LOAD32_IDX = 43,
     CALL_LOAD16_IDX = 44,
-    CALL_LOAD8_IDX  = 45,
+    CALL_LOAD8_IDX = 45,
     CALL_LOADU32_IDX = 46,
     CALL_LOADU16_IDX = 47,
-    CALL_LOADU8_IDX  = 48,
+    CALL_LOADU8_IDX = 48,
     CALL_STORE64_IDX = 49,
     CALL_STORE32_IDX = 50,
     CALL_STORE16_IDX = 51,
-    CALL_STORE8_IDX  = 52,
+    CALL_STORE8_IDX = 52,
     CALL_FLOAT_LOAD64_IDX = 53,
     CALL_FLOAT_LOAD32_IDX = 54,
     CALL_FLOAT_STORE64_IDX = 55,
@@ -91,51 +91,50 @@ pub enum CALL_HELPER_IDX {
 
 #[allow(non_camel_case_types)]
 pub enum CallFcvtIdx {
-    W_S  = 0,
+    W_S = 0,
     WU_S = 1,
-    S_W  = 2,
+    S_W = 2,
     S_WU = 3,
-    S_D  = 4,
-    D_S  = 5,
-    W_D  = 6,
+    S_D = 4,
+    D_S = 5,
+    W_D = 6,
     WU_D = 7,
-    D_W  = 8,
+    D_W = 8,
     D_WU = 9,
-    L_S  = 10,
+    L_S = 10,
     LU_S = 11,
-    S_L  = 12,
+    S_L = 12,
     S_LU = 13,
-    L_D  = 14,
+    L_D = 14,
     LU_D = 15,
-    D_L  = 16,
+    D_L = 16,
     D_LU = 17,
 }
 impl CallFcvtIdx {
     pub fn from_u64(from_bits: u64) -> CallFcvtIdx {
         match from_bits {
-            0  => CallFcvtIdx::W_S ,
-            1  => CallFcvtIdx::WU_S,
-            2  => CallFcvtIdx::S_W ,
-            3  => CallFcvtIdx::S_WU,
-            4  => CallFcvtIdx::S_D ,
-            5  => CallFcvtIdx::D_S ,
-            6  => CallFcvtIdx::W_D ,
-            7  => CallFcvtIdx::WU_D,
-            8  => CallFcvtIdx::D_W ,
-            9  => CallFcvtIdx::D_WU,
-            10 => CallFcvtIdx::L_S ,
+            0 => CallFcvtIdx::W_S,
+            1 => CallFcvtIdx::WU_S,
+            2 => CallFcvtIdx::S_W,
+            3 => CallFcvtIdx::S_WU,
+            4 => CallFcvtIdx::S_D,
+            5 => CallFcvtIdx::D_S,
+            6 => CallFcvtIdx::W_D,
+            7 => CallFcvtIdx::WU_D,
+            8 => CallFcvtIdx::D_W,
+            9 => CallFcvtIdx::D_WU,
+            10 => CallFcvtIdx::L_S,
             11 => CallFcvtIdx::LU_S,
-            12 => CallFcvtIdx::S_L ,
+            12 => CallFcvtIdx::S_L,
             13 => CallFcvtIdx::S_LU,
-            14 => CallFcvtIdx::L_D ,
+            14 => CallFcvtIdx::L_D,
             15 => CallFcvtIdx::LU_D,
-            16 => CallFcvtIdx::D_L ,
+            16 => CallFcvtIdx::D_L,
             17 => CallFcvtIdx::D_LU,
             _ => panic!("Unknown CallFcvtIdx : {:}", from_bits),
         }
     }
 }
-
 
 #[macro_export]
 macro_rules! get_rs1_addr {
@@ -228,7 +227,7 @@ pub struct TranslateRiscv {
 impl TranslateRiscv {
     pub fn new() -> TranslateRiscv {
         let mut trans = TranslateRiscv {
-            reg_bitmap: VecDeque::new()
+            reg_bitmap: VecDeque::new(),
         };
         for idx in 0..5 {
             trans.reg_bitmap.push_back(idx);
@@ -238,9 +237,7 @@ impl TranslateRiscv {
 
     pub fn tcg_temp_new(&mut self) -> TCGv {
         let new_idx = match self.reg_bitmap.pop_front() {
-            Some(idx) => {
-                idx
-            }
+            Some(idx) => idx,
             None => panic!("New temporaries not found."),
         };
         let new_v = TCGv::new_temp(new_idx as u64);
@@ -353,7 +350,7 @@ impl TranslateRiscv {
             RiscvInstId::FMIN_D => self.translate_fmin_d(inst),
             RiscvInstId::FMAX_D => self.translate_fmax_d(inst),
 
-            RiscvInstId::FSGNJ_D  => self.translate_fsgnj_d(inst),
+            RiscvInstId::FSGNJ_D => self.translate_fsgnj_d(inst),
             RiscvInstId::FSGNJN_D => self.translate_fsgnjn_d(inst),
             RiscvInstId::FSGNJX_D => self.translate_fsgnjx_d(inst),
 
@@ -380,97 +377,97 @@ impl TranslateRiscv {
             RiscvInstId::FMIN_S => self.translate_fmin_s(inst),
             RiscvInstId::FMAX_S => self.translate_fmax_s(inst),
 
-            RiscvInstId::FSGNJ_S  => self.translate_fsgnj_s(inst),
+            RiscvInstId::FSGNJ_S => self.translate_fsgnj_s(inst),
             RiscvInstId::FSGNJN_S => self.translate_fsgnjn_s(inst),
             RiscvInstId::FSGNJX_S => self.translate_fsgnjx_s(inst),
 
-            RiscvInstId::MUL    => self.translate_mul(inst),
-            RiscvInstId::MULH   => self.translate_mulh(inst),
-            RiscvInstId::MULHU  => self.translate_mulhu(inst),
+            RiscvInstId::MUL => self.translate_mul(inst),
+            RiscvInstId::MULH => self.translate_mulh(inst),
+            RiscvInstId::MULHU => self.translate_mulhu(inst),
             RiscvInstId::MULHSU => self.translate_mulhsu(inst),
-            RiscvInstId::MULW   => self.translate_mulw(inst),
+            RiscvInstId::MULW => self.translate_mulw(inst),
 
-            RiscvInstId::DIV   => self.translate_div(inst),
-            RiscvInstId::DIVU  => self.translate_divu(inst),
-            RiscvInstId::DIVW  => self.translate_divw(inst),
+            RiscvInstId::DIV => self.translate_div(inst),
+            RiscvInstId::DIVU => self.translate_divu(inst),
+            RiscvInstId::DIVW => self.translate_divw(inst),
             RiscvInstId::DIVUW => self.translate_divuw(inst),
 
-            RiscvInstId::REM   => self.translate_rem(inst),
-            RiscvInstId::REMU  => self.translate_remu(inst),
-            RiscvInstId::REMW  => self.translate_remw(inst),
+            RiscvInstId::REM => self.translate_rem(inst),
+            RiscvInstId::REMU => self.translate_remu(inst),
+            RiscvInstId::REMW => self.translate_remw(inst),
             RiscvInstId::REMUW => self.translate_remuw(inst),
 
-            RiscvInstId::FCVT_W_S  => self.translate_fcvt_w_s(inst),
+            RiscvInstId::FCVT_W_S => self.translate_fcvt_w_s(inst),
             RiscvInstId::FCVT_WU_S => self.translate_fcvt_wu_s(inst),
-            RiscvInstId::FCVT_S_W  => self.translate_fcvt_s_w(inst),
+            RiscvInstId::FCVT_S_W => self.translate_fcvt_s_w(inst),
             RiscvInstId::FCVT_S_WU => self.translate_fcvt_s_wu(inst),
-            RiscvInstId::FCVT_S_D  => self.translate_fcvt_s_d(inst),
-            RiscvInstId::FCVT_D_S  => self.translate_fcvt_d_s(inst),
-            RiscvInstId::FCVT_W_D  => self.translate_fcvt_w_d(inst),
+            RiscvInstId::FCVT_S_D => self.translate_fcvt_s_d(inst),
+            RiscvInstId::FCVT_D_S => self.translate_fcvt_d_s(inst),
+            RiscvInstId::FCVT_W_D => self.translate_fcvt_w_d(inst),
             RiscvInstId::FCVT_WU_D => self.translate_fcvt_wu_d(inst),
-            RiscvInstId::FCVT_D_W  => self.translate_fcvt_d_w(inst),
+            RiscvInstId::FCVT_D_W => self.translate_fcvt_d_w(inst),
             RiscvInstId::FCVT_D_WU => self.translate_fcvt_d_wu(inst),
-            RiscvInstId::FCVT_L_S  => self.translate_fcvt_l_s(inst),
+            RiscvInstId::FCVT_L_S => self.translate_fcvt_l_s(inst),
             RiscvInstId::FCVT_LU_S => self.translate_fcvt_lu_s(inst),
-            RiscvInstId::FCVT_S_L  => self.translate_fcvt_s_l(inst),
+            RiscvInstId::FCVT_S_L => self.translate_fcvt_s_l(inst),
             RiscvInstId::FCVT_S_LU => self.translate_fcvt_s_lu(inst),
-            RiscvInstId::FCVT_L_D  => self.translate_fcvt_l_d(inst),
+            RiscvInstId::FCVT_L_D => self.translate_fcvt_l_d(inst),
             RiscvInstId::FCVT_LU_D => self.translate_fcvt_lu_d(inst),
-            RiscvInstId::FCVT_D_L  => self.translate_fcvt_d_l(inst),
+            RiscvInstId::FCVT_D_L => self.translate_fcvt_d_l(inst),
             RiscvInstId::FCVT_D_LU => self.translate_fcvt_d_lu(inst),
 
             RiscvInstId::C_ADDI4SPN => self.translate_c_addi4spn(inst),
-            RiscvInstId::C_FLD      => self.translate_c_fld     (inst),
-            RiscvInstId::C_LW       => self.translate_c_lw      (inst),
-            RiscvInstId::C_FLW      => self.translate_c_flw     (inst),
-            RiscvInstId::C_LD       => self.translate_c_ld      (inst),
-            RiscvInstId::C_FSD      => self.translate_c_fsd     (inst),
-            RiscvInstId::C_SW       => self.translate_c_sw      (inst),
-            RiscvInstId::C_FSW      => self.translate_c_fsw     (inst),
-            RiscvInstId::C_SD       => self.translate_c_sd      (inst),
-            RiscvInstId::C_NOP      => self.translate_c_nop     (inst),
-            RiscvInstId::C_ADDI     => self.translate_c_addi    (inst),
-            RiscvInstId::C_JAL      => self.translate_c_jal     (inst),
-            RiscvInstId::C_ADDIW    => self.translate_c_addiw   (inst),
-            RiscvInstId::C_LI       => self.translate_c_li      (inst),
+            RiscvInstId::C_FLD => self.translate_c_fld(inst),
+            RiscvInstId::C_LW => self.translate_c_lw(inst),
+            RiscvInstId::C_FLW => self.translate_c_flw(inst),
+            RiscvInstId::C_LD => self.translate_c_ld(inst),
+            RiscvInstId::C_FSD => self.translate_c_fsd(inst),
+            RiscvInstId::C_SW => self.translate_c_sw(inst),
+            RiscvInstId::C_FSW => self.translate_c_fsw(inst),
+            RiscvInstId::C_SD => self.translate_c_sd(inst),
+            RiscvInstId::C_NOP => self.translate_c_nop(inst),
+            RiscvInstId::C_ADDI => self.translate_c_addi(inst),
+            RiscvInstId::C_JAL => self.translate_c_jal(inst),
+            RiscvInstId::C_ADDIW => self.translate_c_addiw(inst),
+            RiscvInstId::C_LI => self.translate_c_li(inst),
             RiscvInstId::C_ADDI16SP => self.translate_c_addi16sp(inst),
-            RiscvInstId::C_LUI      => self.translate_c_lui     (inst),
-            RiscvInstId::C_SRLI     => self.translate_c_srli    (inst),
-            RiscvInstId::C_SRLI64   => self.translate_c_srli64  (inst),
-            RiscvInstId::C_SRAI     => self.translate_c_srai    (inst),
-            RiscvInstId::C_SRAI64   => self.translate_c_srai64  (inst),
-            RiscvInstId::C_ANDI     => self.translate_c_andi    (inst),
-            RiscvInstId::C_SUB      => self.translate_c_sub     (inst),
-            RiscvInstId::C_XOR      => self.translate_c_xor     (inst),
-            RiscvInstId::C_OR       => self.translate_c_or      (inst),
-            RiscvInstId::C_AND      => self.translate_c_and     (inst),
-            RiscvInstId::C_SUBW     => self.translate_c_subw    (inst),
-            RiscvInstId::C_ADDW     => self.translate_c_addw    (inst),
-            RiscvInstId::C_J        => self.translate_c_j       (inst),
-            RiscvInstId::C_BEQZ     => self.translate_c_beqz    (inst),
-            RiscvInstId::C_BNEZ     => self.translate_c_bnez    (inst),
-            RiscvInstId::C_SLLI     => self.translate_c_slli    (inst),
-            RiscvInstId::C_FLDSP    => self.translate_c_fldsp   (inst),
-            RiscvInstId::C_LWSP     => self.translate_c_lwsp    (inst),
-            RiscvInstId::C_FLWSP    => self.translate_c_flwsp   (inst),
-            RiscvInstId::C_LDSP     => self.translate_c_ldsp    (inst),
-            RiscvInstId::C_JR       => self.translate_c_jr      (inst),
-            RiscvInstId::C_MV       => self.translate_c_mv      (inst),
-            RiscvInstId::C_EBREAK   => self.translate_c_ebreak  (inst),
-            RiscvInstId::C_JALR     => self.translate_c_jalr    (inst),
-            RiscvInstId::C_ADD      => self.translate_c_add     (inst),
-            RiscvInstId::C_FSDSP    => self.translate_c_fsdsp   (inst),
-            RiscvInstId::C_SWSP     => self.translate_c_swsp    (inst),
-            RiscvInstId::C_FSWSP    => self.translate_c_fswsp   (inst),
-            RiscvInstId::C_SDSP     => self.translate_c_sdsp    (inst),
+            RiscvInstId::C_LUI => self.translate_c_lui(inst),
+            RiscvInstId::C_SRLI => self.translate_c_srli(inst),
+            RiscvInstId::C_SRLI64 => self.translate_c_srli64(inst),
+            RiscvInstId::C_SRAI => self.translate_c_srai(inst),
+            RiscvInstId::C_SRAI64 => self.translate_c_srai64(inst),
+            RiscvInstId::C_ANDI => self.translate_c_andi(inst),
+            RiscvInstId::C_SUB => self.translate_c_sub(inst),
+            RiscvInstId::C_XOR => self.translate_c_xor(inst),
+            RiscvInstId::C_OR => self.translate_c_or(inst),
+            RiscvInstId::C_AND => self.translate_c_and(inst),
+            RiscvInstId::C_SUBW => self.translate_c_subw(inst),
+            RiscvInstId::C_ADDW => self.translate_c_addw(inst),
+            RiscvInstId::C_J => self.translate_c_j(inst),
+            RiscvInstId::C_BEQZ => self.translate_c_beqz(inst),
+            RiscvInstId::C_BNEZ => self.translate_c_bnez(inst),
+            RiscvInstId::C_SLLI => self.translate_c_slli(inst),
+            RiscvInstId::C_FLDSP => self.translate_c_fldsp(inst),
+            RiscvInstId::C_LWSP => self.translate_c_lwsp(inst),
+            RiscvInstId::C_FLWSP => self.translate_c_flwsp(inst),
+            RiscvInstId::C_LDSP => self.translate_c_ldsp(inst),
+            RiscvInstId::C_JR => self.translate_c_jr(inst),
+            RiscvInstId::C_MV => self.translate_c_mv(inst),
+            RiscvInstId::C_EBREAK => self.translate_c_ebreak(inst),
+            RiscvInstId::C_JALR => self.translate_c_jalr(inst),
+            RiscvInstId::C_ADD => self.translate_c_add(inst),
+            RiscvInstId::C_FSDSP => self.translate_c_fsdsp(inst),
+            RiscvInstId::C_SWSP => self.translate_c_swsp(inst),
+            RiscvInstId::C_FSWSP => self.translate_c_fswsp(inst),
+            RiscvInstId::C_SDSP => self.translate_c_sdsp(inst),
 
             other_id => panic!("InstID={:?} : Not supported these instructions.", other_id),
         };
     }
 
     pub fn translate_rrr(&mut self, op: TCGOpcode, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
-        let rs2_addr= get_rs2_addr!(inst.inst);
+        let rs1_addr = get_rs1_addr!(inst.inst);
+        let rs2_addr = get_rs2_addr!(inst.inst);
         let rd_addr = get_rd_addr!(inst.inst);
 
         if rd_addr == 0 {
@@ -481,7 +478,7 @@ impl TranslateRiscv {
         let source2 = self.tcg_temp_new();
 
         let rs1_op = TCGOp::tcg_get_gpr(source1, rs1_addr);
-        let rs2_op = TCGOp::tcg_get_gpr(source2, rs2_addr);  // Box::new(TCGv::new_reg(rs2_addr as u64));
+        let rs2_op = TCGOp::tcg_get_gpr(source2, rs2_addr); // Box::new(TCGv::new_reg(rs2_addr as u64));
 
         let tcg_inst = TCGOp::new_3op(op, source1, source1, source2);
 
@@ -494,8 +491,8 @@ impl TranslateRiscv {
     }
 
     pub fn translate_rrr_32bit(&mut self, op: TCGOpcode, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
-        let rs2_addr= get_rs2_addr!(inst.inst);
+        let rs1_addr = get_rs1_addr!(inst.inst);
+        let rs2_addr = get_rs2_addr!(inst.inst);
         let rd_addr = get_rd_addr!(inst.inst);
 
         if rd_addr == 0 {
@@ -520,9 +517,8 @@ impl TranslateRiscv {
         tcg_list
     }
 
-
     pub fn translate_rri(&mut self, op: TCGOpcode, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
+        let rs1_addr = get_rs1_addr!(inst.inst);
         let rd_addr = get_rd_addr!(inst.inst);
 
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
@@ -541,8 +537,8 @@ impl TranslateRiscv {
     }
 
     pub fn translate_shift_r(&mut self, op: TCGOpcode, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
-        let rs2_addr= get_rs2_addr!(inst.inst);
+        let rs1_addr = get_rs1_addr!(inst.inst);
+        let rs2_addr = get_rs2_addr!(inst.inst);
         let rd_addr = get_rd_addr!(inst.inst);
 
         if rd_addr == 0 {
@@ -569,7 +565,6 @@ impl TranslateRiscv {
         tcg_list
     }
 
-
     pub fn translate_shift_i(&mut self, op: TCGOpcode, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1_addr = get_rs1_addr!(inst.inst);
         let imm_const: u64 = ((inst.inst >> 20) & 0x3f) as u64;
@@ -583,7 +578,12 @@ impl TranslateRiscv {
 
         let source1 = self.tcg_temp_new();
         tcg_list.push(TCGOp::tcg_get_gpr(source1, rs1_addr));
-        tcg_list.push(TCGOp::new_3op(op, source1, source1, TCGv::new_imm(imm_const)));
+        tcg_list.push(TCGOp::new_3op(
+            op,
+            source1,
+            source1,
+            TCGv::new_imm(imm_const),
+        ));
         if op != TCGOpcode::SLL_64BIT && op != TCGOpcode::SRA_64BIT && op != TCGOpcode::SRL_64BIT {
             tcg_list.push(TCGOp::new_2op(TCGOpcode::SIGN_EXT_32_64, source1, source1));
         }
@@ -635,7 +635,7 @@ impl TranslateRiscv {
         tcg_list.push(TCGOp::new_4op(op, rs1, rs2, addr, Rc::clone(&label)));
         tcg_list.push(TCGOp::new_goto_tb(TCGv::new_imm(inst.addr + 4)));
         tcg_list.push(TCGOp::new_label(Rc::clone(&label)));
-        tcg_list.push(TCGOp::new_goto_tb(TCGv::new_imm(target  as u64)));
+        tcg_list.push(TCGOp::new_goto_tb(TCGv::new_imm(target as u64)));
 
         self.tcg_temp_free(rs2);
         self.tcg_temp_free(rs1);
@@ -655,5 +655,4 @@ impl TranslateRiscv {
         let tcg_inst = TCGOp::new_3op(op, *rd, *rs1, *imm);
         return vec![tcg_inst];
     }
-
 }

--- a/src/target/riscv/riscv_decoder.rs
+++ b/src/target/riscv/riscv_decoder.rs
@@ -1,13 +1,12 @@
 /* CAUTION! THIS SOURCE CODE IS GENERATED AUTOMATICALLY. DON'T MODIFY BY HAND. */
 
-
-use super::riscv_inst_id::RiscvInstId;
 use super::riscv_decoder_extra;
+use super::riscv_inst_id::RiscvInstId;
 
-pub fn decode_inst (inst: u32) -> Option<(RiscvInstId, usize)> {
+pub fn decode_inst(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_ld = ((inst as u64) >> 0) & (((1 as u64) << 2) - 1);
     return match field_ld {
-        0x03 => 
+        0x03 =>
         // Remaining Instruction is 164
         // lui        r[11:7],h[31:12]
         // auipc      r[11:7],h[31:12]
@@ -173,8 +172,10 @@ pub fn decode_inst (inst: u32) -> Option<(RiscvInstId, usize)> {
         // fcvt.d.l   f[11:7],r[19:15]
         // fcvt.d.lu  f[11:7],r[19:15]
         // fmv.d.x    f[11:7],r[19:15]
-        decode_inst_ld_11 (inst),
-        0x00 => 
+        {
+            decode_inst_ld_11(inst)
+        }
+        0x00 =>
         // Remaining Instruction is 9
         // c.addi4spn cr[4:2],u[12:5]
         // c.fld      cf[4:2],cr[9:7],u[6:5]|u[12:10]<<3
@@ -185,10 +186,12 @@ pub fn decode_inst (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.sw       cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 21
-        // c.nop     
+        // c.nop
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
@@ -209,39 +212,39 @@ pub fn decode_inst (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.j        u[12:12]|u[8:8]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.beqz     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01 (inst),
-        0x02 => 
+        {
+            decode_inst_ld_01(inst)
+        }
+        0x02 =>
         // Remaining Instruction is 14
         // c.slli     r[11:7],u[12:12]|u[6:2]
-        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3 
+        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.lwsp     r[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.flwsp    f[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.jr       r[11:7]
         // c.mv       r[11:7],r[6:2]
-        // c.ebreak  
+        // c.ebreak
         // c.jalr     r[11:7]
         // c.add      r[11:7],r[6:2]
         // c.fsdsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.swsp     r[6:2],u[8:7]|u[12:9]<<2
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
-        0x0d => 
-        Some((RiscvInstId::LUI, 4)),
-        0x05 => 
-        Some((RiscvInstId::AUIPC, 4)),
-        0x1b => 
-        Some((RiscvInstId::JAL, 4)),
-        0x19 => 
-        Some((RiscvInstId::JALR, 4)),
-        0x18 => 
+        0x0d => Some((RiscvInstId::LUI, 4)),
+        0x05 => Some((RiscvInstId::AUIPC, 4)),
+        0x1b => Some((RiscvInstId::JAL, 4)),
+        0x19 => Some((RiscvInstId::JALR, 4)),
+        0x18 =>
         // Remaining Instruction is 6
         // beq        r[19:15],r[24:20],u[31:31]|u[7:7]|u[30:25]|u[11:8]<<1
         // bne        r[19:15],r[24:20],u[31:31]|u[7:7]|u[30:25]|u[11:8]<<1
@@ -249,8 +252,10 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // bge        r[19:15],r[24:20],u[31:31]|u[7:7]|u[30:25]|u[11:8]<<1
         // bltu       r[19:15],r[24:20],u[31:31]|u[7:7]|u[30:25]|u[11:8]<<1
         // bgeu       r[19:15],r[24:20],u[31:31]|u[7:7]|u[30:25]|u[11:8]<<1
-        decode_inst_ld_11_op_11000 (inst),
-        0x00 => 
+        {
+            decode_inst_ld_11_op_11000(inst)
+        }
+        0x00 =>
         // Remaining Instruction is 7
         // lb         r[11:7],h[31:20](r[19:15])
         // lh         r[11:7],h[31:20](r[19:15])
@@ -259,15 +264,19 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // lhu        r[11:7],h[31:20](r[19:15])
         // lwu        r[11:7],h[31:20](r[19:15])
         // ld         r[11:7],h[31:20](r[19:15])
-        decode_inst_ld_11_op_00000 (inst),
-        0x08 => 
+        {
+            decode_inst_ld_11_op_00000(inst)
+        }
+        0x08 =>
         // Remaining Instruction is 4
         // sb         r[24:20],h[31:25]|h[11:7](r[19:15])
         // sh         r[24:20],h[31:25]|h[11:7](r[19:15])
         // sw         r[24:20],h[31:25]|h[11:7](r[19:15])
         // sd         r[24:20],h[31:25]|h[11:7](r[19:15])
-        decode_inst_ld_11_op_01000 (inst),
-        0x04 => 
+        {
+            decode_inst_ld_11_op_01000(inst)
+        }
+        0x04 =>
         // Remaining Instruction is 9
         // addi       r[11:7],r[19:15],h[31:20]
         // slti       r[11:7],r[19:15],h[31:20]
@@ -278,8 +287,10 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // slli       r[11:7],r[19:15],h[25:20]
         // srli       r[11:7],r[19:15],h[24:20]
         // srai       r[11:7],r[19:15],h[24:20]
-        decode_inst_ld_11_op_00100 (inst),
-        0x0c => 
+        {
+            decode_inst_ld_11_op_00100(inst)
+        }
+        0x0c =>
         // Remaining Instruction is 18
         // add        r[11:7],r[19:15],r[24:20]
         // sub        r[11:7],r[19:15],r[24:20]
@@ -299,13 +310,17 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // divu       r[11:7],r[19:15],r[24:20]
         // rem        r[11:7],r[19:15],r[24:20]
         // remu       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01100 (inst),
-        0x03 => 
+        {
+            decode_inst_ld_11_op_01100(inst)
+        }
+        0x03 =>
         // Remaining Instruction is 2
         // fence
         // fence.i
-        decode_inst_ld_11_op_00011 (inst),
-        0x0b => 
+        {
+            decode_inst_ld_11_op_00011(inst)
+        }
+        0x0b =>
         // Remaining Instruction is 22
         // lr.w       r[11:7],r[19:15]
         // sc.w       r[11:7],r[19:15],r[24:20]
@@ -329,38 +344,52 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // amomax.d   r[11:7],r[24:20],(r[19:15])
         // amominu.d  r[11:7],r[24:20],(r[19:15])
         // amomaxu.d  r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_01011(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 2
         // flw        f[11:7],h[31:20](r[19:15])
         // fld        f[11:7],r[19:15],h[31:20]
-        decode_inst_ld_11_op_00001 (inst),
-        0x09 => 
+        {
+            decode_inst_ld_11_op_00001(inst)
+        }
+        0x09 =>
         // Remaining Instruction is 2
         // fsw        f[24:20],h[31:25]|h[11:7](r[19:15])
         // fsd        f[24:20],h[31:25]|h[11:7](r[19:15])
-        decode_inst_ld_11_op_01001 (inst),
-        0x10 => 
+        {
+            decode_inst_ld_11_op_01001(inst)
+        }
+        0x10 =>
         // Remaining Instruction is 2
         // fmadd.s    f[11:7],f[19:15],f[24:20],f[31:27]
         // fmadd.d    f[11:7],f[19:15],f[24:20],f[31:27]
-        decode_inst_ld_11_op_10000 (inst),
-        0x11 => 
+        {
+            decode_inst_ld_11_op_10000(inst)
+        }
+        0x11 =>
         // Remaining Instruction is 2
         // fmsub.s    f[11:7],f[19:15],f[24:20],f[31:27]
         // fmsub.d    f[11:7],f[19:15],f[24:20],f[31:27]
-        decode_inst_ld_11_op_10001 (inst),
-        0x12 => 
+        {
+            decode_inst_ld_11_op_10001(inst)
+        }
+        0x12 =>
         // Remaining Instruction is 2
         // fnmsub.s   f[11:7],f[19:15],f[24:20],f[31:27]
         // fnmsub.d   f[11:7],f[19:15],f[24:20],f[31:27]
-        decode_inst_ld_11_op_10010 (inst),
-        0x13 => 
+        {
+            decode_inst_ld_11_op_10010(inst)
+        }
+        0x13 =>
         // Remaining Instruction is 2
         // fnmadd.s   f[11:7],f[19:15],f[24:20],f[31:27]
         // fnmadd.d   f[11:7],f[19:15],f[24:20],f[31:27]
-        decode_inst_ld_11_op_10011 (inst),
-        0x14 => 
+        {
+            decode_inst_ld_11_op_10011(inst)
+        }
+        0x14 =>
         // Remaining Instruction is 50
         // fadd.s     f[11:7],f[19:15],f[24:20]
         // fsub.s     f[11:7],f[19:15],f[24:20]
@@ -412,8 +441,10 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // fcvt.d.l   f[11:7],r[19:15]
         // fcvt.d.lu  f[11:7],r[19:15]
         // fmv.d.x    f[11:7],r[19:15]
-        decode_inst_ld_11_op_10100 (inst),
-        0x1c => 
+        {
+            decode_inst_ld_11_op_10100(inst)
+        }
+        0x1c =>
         // Remaining Instruction is 16
         // csrrw      r[11:7],h[31:20],r[19:15]
         // csrrs      r[11:7],h[31:20],r[19:15]
@@ -431,15 +462,19 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // mrth
         // wfi
         // sfence.vma r[19:15],r[24:20]
-        decode_inst_ld_11_op_11100 (inst),
-        0x06 => 
+        {
+            decode_inst_ld_11_op_11100(inst)
+        }
+        0x06 =>
         // Remaining Instruction is 4
         // addiw      r[11:7],r[19:15],h[31:20]
         // slliw      r[11:7],r[19:15],r[24:20]
         // srliw      r[11:7],r[19:15],r[24:20]
         // sraiw      r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_00110 (inst),
-        0x0e => 
+        {
+            decode_inst_ld_11_op_00110(inst)
+        }
+        0x0e =>
         // Remaining Instruction is 10
         // addw       r[11:7],r[19:15],r[24:20]
         // subw       r[11:7],r[19:15],r[24:20]
@@ -451,101 +486,79 @@ fn decode_inst_ld_11 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // divuw      r[11:7],r[19:15],r[24:20]
         // remw       r[11:7],r[19:15],r[24:20]
         // remuw      r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01110 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01110(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::BEQ, 4)),
-        0x01 => 
-        Some((RiscvInstId::BNE, 4)),
-        0x04 => 
-        Some((RiscvInstId::BLT, 4)),
-        0x05 => 
-        Some((RiscvInstId::BGE, 4)),
-        0x06 => 
-        Some((RiscvInstId::BLTU, 4)),
-        0x07 => 
-        Some((RiscvInstId::BGEU, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::BEQ, 4)),
+        0x01 => Some((RiscvInstId::BNE, 4)),
+        0x04 => Some((RiscvInstId::BLT, 4)),
+        0x05 => Some((RiscvInstId::BGE, 4)),
+        0x06 => Some((RiscvInstId::BLTU, 4)),
+        0x07 => Some((RiscvInstId::BGEU, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::LB, 4)),
-        0x01 => 
-        Some((RiscvInstId::LH, 4)),
-        0x02 => 
-        Some((RiscvInstId::LW, 4)),
-        0x04 => 
-        Some((RiscvInstId::LBU, 4)),
-        0x05 => 
-        Some((RiscvInstId::LHU, 4)),
-        0x06 => 
-        Some((RiscvInstId::LWU, 4)),
-        0x03 => 
-        Some((RiscvInstId::LD, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::LB, 4)),
+        0x01 => Some((RiscvInstId::LH, 4)),
+        0x02 => Some((RiscvInstId::LW, 4)),
+        0x04 => Some((RiscvInstId::LBU, 4)),
+        0x05 => Some((RiscvInstId::LHU, 4)),
+        0x06 => Some((RiscvInstId::LWU, 4)),
+        0x03 => Some((RiscvInstId::LD, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::SB, 4)),
-        0x01 => 
-        Some((RiscvInstId::SH, 4)),
-        0x02 => 
-        Some((RiscvInstId::SW, 4)),
-        0x03 => 
-        Some((RiscvInstId::SD, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::SB, 4)),
+        0x01 => Some((RiscvInstId::SH, 4)),
+        0x02 => Some((RiscvInstId::SW, 4)),
+        0x03 => Some((RiscvInstId::SD, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::ADDI, 4)),
-        0x02 => 
-        Some((RiscvInstId::SLTI, 4)),
-        0x03 => 
-        Some((RiscvInstId::SLTIU, 4)),
-        0x04 => 
-        Some((RiscvInstId::XORI, 4)),
-        0x06 => 
-        Some((RiscvInstId::ORI, 4)),
-        0x07 => 
-        Some((RiscvInstId::ANDI, 4)),
-        0x01 => 
-        Some((RiscvInstId::SLLI, 4)),
-        0x05 => 
+        0x00 => Some((RiscvInstId::ADDI, 4)),
+        0x02 => Some((RiscvInstId::SLTI, 4)),
+        0x03 => Some((RiscvInstId::SLTIU, 4)),
+        0x04 => Some((RiscvInstId::XORI, 4)),
+        0x06 => Some((RiscvInstId::ORI, 4)),
+        0x07 => Some((RiscvInstId::ANDI, 4)),
+        0x01 => Some((RiscvInstId::SLLI, 4)),
+        0x05 =>
         // Remaining Instruction is 2
         // srli       r[11:7],r[19:15],h[24:20]
         // srai       r[11:7],r[19:15],h[24:20]
-        decode_inst_ld_11_op_00100_f3_101 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_00100_f3_101(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00100_f3_101 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00100_f3_101(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 => 
-        Some((RiscvInstId::SRLI, 4)),
-        0x08 => 
-        Some((RiscvInstId::SRAI, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::SRLI, 4)),
+        0x08 => Some((RiscvInstId::SRAI, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 16
         // add        r[11:7],r[19:15],r[24:20]
         // sll        r[11:7],r[19:15],r[24:20]
@@ -563,19 +576,23 @@ fn decode_inst_ld_11_op_01100 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // divu       r[11:7],r[19:15],r[24:20]
         // rem        r[11:7],r[19:15],r[24:20]
         // remu       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01100_r3_00000 (inst),
-        0x08 => 
+        {
+            decode_inst_ld_11_op_01100_r3_00000(inst)
+        }
+        0x08 =>
         // Remaining Instruction is 2
         // sub        r[11:7],r[19:15],r[24:20]
         // sra        r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01100_r3_01000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01100_r3_01000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01100_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01100_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 8
         // add        r[11:7],r[19:15],r[24:20]
         // sll        r[11:7],r[19:15],r[24:20]
@@ -585,8 +602,10 @@ fn decode_inst_ld_11_op_01100_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize
         // srl        r[11:7],r[19:15],r[24:20]
         // or         r[11:7],r[19:15],r[24:20]
         // and        r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01100_r3_00000_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_01100_r3_00000_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 8
         // mul        r[11:7],r[19:15],r[24:20]
         // mulh       r[11:7],r[19:15],r[24:20]
@@ -596,367 +615,353 @@ fn decode_inst_ld_11_op_01100_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize
         // divu       r[11:7],r[19:15],r[24:20]
         // rem        r[11:7],r[19:15],r[24:20]
         // remu       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01100_r3_00000_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01100_r3_00000_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01100_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01100_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::ADD, 4)),
-        0x01 => 
-        Some((RiscvInstId::SLL, 4)),
-        0x02 => 
-        Some((RiscvInstId::SLT, 4)),
-        0x03 => 
-        Some((RiscvInstId::SLTU, 4)),
-        0x04 => 
-        Some((RiscvInstId::XOR, 4)),
-        0x05 => 
-        Some((RiscvInstId::SRL, 4)),
-        0x06 => 
-        Some((RiscvInstId::OR, 4)),
-        0x07 => 
-        Some((RiscvInstId::AND, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::ADD, 4)),
+        0x01 => Some((RiscvInstId::SLL, 4)),
+        0x02 => Some((RiscvInstId::SLT, 4)),
+        0x03 => Some((RiscvInstId::SLTU, 4)),
+        0x04 => Some((RiscvInstId::XOR, 4)),
+        0x05 => Some((RiscvInstId::SRL, 4)),
+        0x06 => Some((RiscvInstId::OR, 4)),
+        0x07 => Some((RiscvInstId::AND, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01100_r3_00000_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01100_r3_00000_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::MUL, 4)),
-        0x01 => 
-        Some((RiscvInstId::MULH, 4)),
-        0x02 => 
-        Some((RiscvInstId::MULHSU, 4)),
-        0x03 => 
-        Some((RiscvInstId::MULHU, 4)),
-        0x04 => 
-        Some((RiscvInstId::DIV, 4)),
-        0x05 => 
-        Some((RiscvInstId::DIVU, 4)),
-        0x06 => 
-        Some((RiscvInstId::REM, 4)),
-        0x07 => 
-        Some((RiscvInstId::REMU, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::MUL, 4)),
+        0x01 => Some((RiscvInstId::MULH, 4)),
+        0x02 => Some((RiscvInstId::MULHSU, 4)),
+        0x03 => Some((RiscvInstId::MULHU, 4)),
+        0x04 => Some((RiscvInstId::DIV, 4)),
+        0x05 => Some((RiscvInstId::DIVU, 4)),
+        0x06 => Some((RiscvInstId::REM, 4)),
+        0x07 => Some((RiscvInstId::REMU, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01100_r3_01000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01100_r3_01000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // sub        r[11:7],r[19:15],r[24:20]
         // sra        r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01100_r3_01000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01100_r3_01000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01100_r3_01000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01100_r3_01000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::SUB, 4)),
-        0x05 => 
-        Some((RiscvInstId::SRA, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::SUB, 4)),
+        0x05 => Some((RiscvInstId::SRA, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00011 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00011(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // fence
         // fence.i
-        decode_inst_ld_11_op_00011_r1_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_00011_r1_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00011_r1_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00011_r1_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::FENCE, 4)),
-        0x01 => 
-        Some((RiscvInstId::FENCE_I, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FENCE, 4)),
+        0x01 => Some((RiscvInstId::FENCE_I, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x02 => 
+        0x02 =>
         // Remaining Instruction is 2
         // lr.w       r[11:7],r[19:15]
         // lr.d       r[11:7],r[19:15]
-        decode_inst_ld_11_op_01011_r3_00010 (inst),
-        0x03 => 
+        {
+            decode_inst_ld_11_op_01011_r3_00010(inst)
+        }
+        0x03 =>
         // Remaining Instruction is 2
         // sc.w       r[11:7],r[19:15],r[24:20]
         // sc.d       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01011_r3_00011 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_01011_r3_00011(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 2
         // amoswap.w  r[11:7],r[24:20],(r[19:15])
         // amoswap.d  r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_00001 (inst),
-        0x00 => 
+        {
+            decode_inst_ld_11_op_01011_r3_00001(inst)
+        }
+        0x00 =>
         // Remaining Instruction is 2
         // amoadd.w   r[11:7],r[24:20],(r[19:15])
         // amoadd.d   r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_00000 (inst),
-        0x04 => 
+        {
+            decode_inst_ld_11_op_01011_r3_00000(inst)
+        }
+        0x04 =>
         // Remaining Instruction is 2
         // amoxor.w   r[11:7],r[24:20],(r[19:15])
         // amoxor.d   r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_00100 (inst),
-        0x0c => 
+        {
+            decode_inst_ld_11_op_01011_r3_00100(inst)
+        }
+        0x0c =>
         // Remaining Instruction is 2
         // amoand.w   r[11:7],r[24:20],(r[19:15])
         // amoand.d   r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_01100 (inst),
-        0x08 => 
+        {
+            decode_inst_ld_11_op_01011_r3_01100(inst)
+        }
+        0x08 =>
         // Remaining Instruction is 2
         // amoor.w    r[11:7],r[24:20],(r[19:15])
         // amoor.d    r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_01000 (inst),
-        0x10 => 
+        {
+            decode_inst_ld_11_op_01011_r3_01000(inst)
+        }
+        0x10 =>
         // Remaining Instruction is 2
         // amomin.w   r[11:7],r[24:20],(r[19:15])
         // amomin.d   r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_10000 (inst),
-        0x14 => 
+        {
+            decode_inst_ld_11_op_01011_r3_10000(inst)
+        }
+        0x14 =>
         // Remaining Instruction is 2
         // amomax.w   r[11:7],r[24:20],(r[19:15])
         // amomax.d   r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_10100 (inst),
-        0x18 => 
+        {
+            decode_inst_ld_11_op_01011_r3_10100(inst)
+        }
+        0x18 =>
         // Remaining Instruction is 2
         // amominu.w  r[11:7],r[24:20],(r[19:15])
         // amominu.d  r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_11000 (inst),
-        0x1c => 
+        {
+            decode_inst_ld_11_op_01011_r3_11000(inst)
+        }
+        0x1c =>
         // Remaining Instruction is 2
         // amomaxu.w  r[11:7],r[24:20],(r[19:15])
         // amomaxu.d  r[11:7],r[24:20],(r[19:15])
-        decode_inst_ld_11_op_01011_r3_11100 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01011_r3_11100(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_00010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_00010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // lr.w       r[11:7],r[19:15]
         // lr.d       r[11:7],r[19:15]
-        decode_inst_ld_11_op_01011_r3_00010_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01011_r3_00010_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_00010_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_00010_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::LR_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::LR_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::LR_W, 4)),
+        0x03 => Some((RiscvInstId::LR_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_00011 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_00011(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::SC_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::SC_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::SC_W, 4)),
+        0x03 => Some((RiscvInstId::SC_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOSWAP_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOSWAP_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOSWAP_W, 4)),
+        0x03 => Some((RiscvInstId::AMOSWAP_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOADD_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOADD_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOADD_W, 4)),
+        0x03 => Some((RiscvInstId::AMOADD_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_00100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_00100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOXOR_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOXOR_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOXOR_W, 4)),
+        0x03 => Some((RiscvInstId::AMOXOR_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_01100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_01100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOAND_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOAND_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOAND_W, 4)),
+        0x03 => Some((RiscvInstId::AMOAND_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_01000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_01000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOOR_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOOR_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOOR_W, 4)),
+        0x03 => Some((RiscvInstId::AMOOR_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_10000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_10000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOMIN_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOMIN_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOMIN_W, 4)),
+        0x03 => Some((RiscvInstId::AMOMIN_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_10100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOMAX_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOMAX_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOMAX_W, 4)),
+        0x03 => Some((RiscvInstId::AMOMAX_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_11000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_11000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOMINU_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOMINU_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOMINU_W, 4)),
+        0x03 => Some((RiscvInstId::AMOMINU_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01011_r3_11100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01011_r3_11100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::AMOMAXU_W, 4)),
-        0x03 => 
-        Some((RiscvInstId::AMOMAXU_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::AMOMAXU_W, 4)),
+        0x03 => Some((RiscvInstId::AMOMAXU_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::FLW, 4)),
-        0x03 => 
-        Some((RiscvInstId::FLD, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::FLW, 4)),
+        0x03 => Some((RiscvInstId::FLD, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::FSW, 4)),
-        0x03 => 
-        Some((RiscvInstId::FSD, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::FSW, 4)),
+        0x03 => Some((RiscvInstId::FSD, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FMADD_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FMADD_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMADD_S, 4)),
+        0x01 => Some((RiscvInstId::FMADD_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FMSUB_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FMSUB_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMSUB_S, 4)),
+        0x01 => Some((RiscvInstId::FMSUB_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FNMSUB_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FNMSUB_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FNMSUB_S, 4)),
+        0x01 => Some((RiscvInstId::FNMSUB_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10011 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10011(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FNMADD_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FNMADD_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FNMADD_S, 4)),
+        0x01 => Some((RiscvInstId::FNMADD_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // fadd.s     f[11:7],f[19:15],f[24:20]
         // fadd.d     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00000 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00000(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 2
         // fsub.s     f[11:7],f[19:15],f[24:20]
         // fsub.d     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00001 (inst),
-        0x02 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00001(inst)
+        }
+        0x02 =>
         // Remaining Instruction is 2
         // fmul.s     f[11:7],f[19:15],f[24:20]
         // fmul.d     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00010 (inst),
-        0x03 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00010(inst)
+        }
+        0x03 =>
         // Remaining Instruction is 2
         // fdiv.s     f[11:7],f[19:15],f[24:20]
         // fdiv.d     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00011 (inst),
-        0x0b => 
+        {
+            decode_inst_ld_11_op_10100_r3_00011(inst)
+        }
+        0x0b =>
         // Remaining Instruction is 2
         // fsqrt.s    f[11:7],f[19:15]
         // fsqrt.d    f[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_01011 (inst),
-        0x04 => 
+        {
+            decode_inst_ld_11_op_10100_r3_01011(inst)
+        }
+        0x04 =>
         // Remaining Instruction is 6
         // fsgnj.s    f[11:7],f[19:15],f[24:20]
         // fsgnjn.s   f[11:7],f[19:15],f[24:20]
@@ -964,15 +969,19 @@ fn decode_inst_ld_11_op_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // fsgnj.d    f[11:7],f[19:15],f[24:20]
         // fsgnjn.d   f[11:7],f[19:15],f[24:20]
         // fsgnjx.d   f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00100 (inst),
-        0x05 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00100(inst)
+        }
+        0x05 =>
         // Remaining Instruction is 4
         // fmin.s     f[11:7],f[19:15],f[24:20]
         // fmax.s     f[11:7],f[19:15],f[24:20]
         // fmin.d     f[11:7],f[19:15],f[24:20]
         // fmax.d     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00101 (inst),
-        0x18 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00101(inst)
+        }
+        0x18 =>
         // Remaining Instruction is 8
         // fcvt.w.s   r[11:7],f[19:15]
         // fcvt.wu.s  r[11:7],f[19:15]
@@ -982,15 +991,19 @@ fn decode_inst_ld_11_op_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // fcvt.lu.s  r[11:7],f[19:15]
         // fcvt.l.d   r[11:7],f[19:15]
         // fcvt.lu.d  r[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11000 (inst),
-        0x1c => 
+        {
+            decode_inst_ld_11_op_10100_r3_11000(inst)
+        }
+        0x1c =>
         // Remaining Instruction is 4
         // fmv.x.w    r[11:7],f[19:15]
         // fclass.s   f[11:7],f[19:15]
         // fclass.d   r[11:7],f[19:15]
         // fmv.x.d    r[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11100 (inst),
-        0x14 => 
+        {
+            decode_inst_ld_11_op_10100_r3_11100(inst)
+        }
+        0x14 =>
         // Remaining Instruction is 6
         // feq.s      r[11:7],f[19:15],f[24:20]
         // flt.s      r[11:7],f[19:15],f[24:20]
@@ -998,8 +1011,10 @@ fn decode_inst_ld_11_op_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // feq.d      r[11:7],f[19:15],f[24:20]
         // flt.d      r[11:7],f[19:15],f[24:20]
         // fle.d      r[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_10100 (inst),
-        0x1a => 
+        {
+            decode_inst_ld_11_op_10100_r3_10100(inst)
+        }
+        0x1a =>
         // Remaining Instruction is 8
         // fcvt.s.w   f[11:7],r[19:15]
         // fcvt.s.wu  f[11:7],r[19:15]
@@ -1009,380 +1024,358 @@ fn decode_inst_ld_11_op_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // fcvt.s.lu  f[11:7],r[19:15]
         // fcvt.d.l   f[11:7],r[19:15]
         // fcvt.d.lu  f[11:7],r[19:15]
-        decode_inst_ld_11_op_10100_r3_11010 (inst),
-        0x1e => 
+        {
+            decode_inst_ld_11_op_10100_r3_11010(inst)
+        }
+        0x1e =>
         // Remaining Instruction is 2
         // fmv.w.x    f[11:7],r[19:15]
         // fmv.d.x    f[11:7],r[19:15]
-        decode_inst_ld_11_op_10100_r3_11110 (inst),
-        0x08 => 
+        {
+            decode_inst_ld_11_op_10100_r3_11110(inst)
+        }
+        0x08 =>
         // Remaining Instruction is 2
         // fcvt.s.d   f[11:7],f[19:15]
         // fcvt.d.s   f[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_01000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_01000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FADD_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FADD_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FADD_S, 4)),
+        0x01 => Some((RiscvInstId::FADD_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FSUB_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FSUB_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FSUB_S, 4)),
+        0x01 => Some((RiscvInstId::FSUB_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FMUL_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FMUL_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMUL_S, 4)),
+        0x01 => Some((RiscvInstId::FMUL_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00011 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00011(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FDIV_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FDIV_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FDIV_S, 4)),
+        0x01 => Some((RiscvInstId::FDIV_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_01011 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_01011(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FSQRT_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FSQRT_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FSQRT_S, 4)),
+        0x01 => Some((RiscvInstId::FSQRT_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // fsgnj.s    f[11:7],f[19:15],f[24:20]
         // fsgnjn.s   f[11:7],f[19:15],f[24:20]
         // fsgnjx.s   f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00100_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00100_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 3
         // fsgnj.d    f[11:7],f[19:15],f[24:20]
         // fsgnjn.d   f[11:7],f[19:15],f[24:20]
         // fsgnjx.d   f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00100_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_00100_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00100_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00100_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::FSGNJ_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FSGNJN_S, 4)),
-        0x02 => 
-        Some((RiscvInstId::FSGNJX_S, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FSGNJ_S, 4)),
+        0x01 => Some((RiscvInstId::FSGNJN_S, 4)),
+        0x02 => Some((RiscvInstId::FSGNJX_S, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00100_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00100_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::FSGNJ_D, 4)),
-        0x01 => 
-        Some((RiscvInstId::FSGNJN_D, 4)),
-        0x02 => 
-        Some((RiscvInstId::FSGNJX_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FSGNJ_D, 4)),
+        0x01 => Some((RiscvInstId::FSGNJN_D, 4)),
+        0x02 => Some((RiscvInstId::FSGNJX_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00101 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00101(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // fmin.s     f[11:7],f[19:15],f[24:20]
         // fmax.s     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00101_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_00101_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 2
         // fmin.d     f[11:7],f[19:15],f[24:20]
         // fmax.d     f[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_00101_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_00101_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00101_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00101_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::FMIN_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FMAX_S, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMIN_S, 4)),
+        0x01 => Some((RiscvInstId::FMAX_S, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_00101_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_00101_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::FMIN_D, 4)),
-        0x01 => 
-        Some((RiscvInstId::FMAX_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMIN_D, 4)),
+        0x01 => Some((RiscvInstId::FMAX_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 4
         // fcvt.w.s   r[11:7],f[19:15]
         // fcvt.wu.s  r[11:7],f[19:15]
         // fcvt.l.s   r[11:7],f[19:15]
         // fcvt.lu.s  r[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11000_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_11000_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 4
         // fcvt.w.d   r[11:7],f[19:15]
         // fcvt.wu.d  r[11:7],f[19:15]
         // fcvt.l.d   r[11:7],f[19:15]
         // fcvt.lu.d  r[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11000_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_11000_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
-        Some((RiscvInstId::FCVT_W_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FCVT_WU_S, 4)),
-        0x02 => 
-        Some((RiscvInstId::FCVT_L_S, 4)),
-        0x03 => 
-        Some((RiscvInstId::FCVT_LU_S, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FCVT_W_S, 4)),
+        0x01 => Some((RiscvInstId::FCVT_WU_S, 4)),
+        0x02 => Some((RiscvInstId::FCVT_L_S, 4)),
+        0x03 => Some((RiscvInstId::FCVT_LU_S, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11000_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11000_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
-        Some((RiscvInstId::FCVT_W_D, 4)),
-        0x01 => 
-        Some((RiscvInstId::FCVT_WU_D, 4)),
-        0x02 => 
-        Some((RiscvInstId::FCVT_L_D, 4)),
-        0x03 => 
-        Some((RiscvInstId::FCVT_LU_D, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FCVT_W_D, 4)),
+        0x01 => Some((RiscvInstId::FCVT_WU_D, 4)),
+        0x02 => Some((RiscvInstId::FCVT_L_D, 4)),
+        0x03 => Some((RiscvInstId::FCVT_LU_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // fmv.x.w    r[11:7],f[19:15]
         // fclass.s   f[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11100_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_11100_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 2
         // fclass.d   r[11:7],f[19:15]
         // fmv.x.d    r[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11100_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_11100_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11100_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11100_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // fmv.x.w    r[11:7],f[19:15]
         // fclass.s   f[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11100_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_11100_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11100_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11100_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::FMV_X_W, 4)),
-        0x01 => 
-        Some((RiscvInstId::FCLASS_S, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMV_X_W, 4)),
+        0x01 => Some((RiscvInstId::FCLASS_S, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11100_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11100_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // fclass.d   r[11:7],f[19:15]
         // fmv.x.d    r[11:7],f[19:15]
-        decode_inst_ld_11_op_10100_r3_11100_f2_01_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_11100_f2_01_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11100_f2_01_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11100_f2_01_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x01 => 
-        Some((RiscvInstId::FCLASS_D, 4)),
-        0x00 => 
-        Some((RiscvInstId::FMV_X_D, 4)),
-      _ => None,
-    }
+        0x01 => Some((RiscvInstId::FCLASS_D, 4)),
+        0x00 => Some((RiscvInstId::FMV_X_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_10100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_10100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // feq.s      r[11:7],f[19:15],f[24:20]
         // flt.s      r[11:7],f[19:15],f[24:20]
         // fle.s      r[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_10100_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_10100_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 3
         // feq.d      r[11:7],f[19:15],f[24:20]
         // flt.d      r[11:7],f[19:15],f[24:20]
         // fle.d      r[11:7],f[19:15],f[24:20]
-        decode_inst_ld_11_op_10100_r3_10100_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_10100_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_10100_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_10100_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::FEQ_S, 4)),
-        0x01 => 
-        Some((RiscvInstId::FLT_S, 4)),
-        0x00 => 
-        Some((RiscvInstId::FLE_S, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::FEQ_S, 4)),
+        0x01 => Some((RiscvInstId::FLT_S, 4)),
+        0x00 => Some((RiscvInstId::FLE_S, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_10100_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_10100_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 => 
-        Some((RiscvInstId::FEQ_D, 4)),
-        0x01 => 
-        Some((RiscvInstId::FLT_D, 4)),
-        0x00 => 
-        Some((RiscvInstId::FLE_D, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::FEQ_D, 4)),
+        0x01 => Some((RiscvInstId::FLT_D, 4)),
+        0x00 => Some((RiscvInstId::FLE_D, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 4
         // fcvt.s.w   f[11:7],r[19:15]
         // fcvt.s.wu  f[11:7],r[19:15]
         // fcvt.s.l   f[11:7],r[19:15]
         // fcvt.s.lu  f[11:7],r[19:15]
-        decode_inst_ld_11_op_10100_r3_11010_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_10100_r3_11010_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 4
         // fcvt.d.w   f[11:7],r[19:15]
         // fcvt.d.wu  f[11:7],r[19:15]
         // fcvt.d.l   f[11:7],r[19:15]
         // fcvt.d.lu  f[11:7],r[19:15]
-        decode_inst_ld_11_op_10100_r3_11010_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_10100_r3_11010_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11010_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11010_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
-        Some((RiscvInstId::FCVT_S_W, 4)),
-        0x01 => 
-        Some((RiscvInstId::FCVT_S_WU, 4)),
-        0x02 => 
-        Some((RiscvInstId::FCVT_S_L, 4)),
-        0x03 => 
-        Some((RiscvInstId::FCVT_S_LU, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FCVT_S_W, 4)),
+        0x01 => Some((RiscvInstId::FCVT_S_WU, 4)),
+        0x02 => Some((RiscvInstId::FCVT_S_L, 4)),
+        0x03 => Some((RiscvInstId::FCVT_S_LU, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11010_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11010_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
-        Some((RiscvInstId::FCVT_D_W, 4)),
-        0x01 => 
-        Some((RiscvInstId::FCVT_D_WU, 4)),
-        0x02 => 
-        Some((RiscvInstId::FCVT_D_L, 4)),
-        0x03 => 
-        Some((RiscvInstId::FCVT_D_LU, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FCVT_D_W, 4)),
+        0x01 => Some((RiscvInstId::FCVT_D_WU, 4)),
+        0x02 => Some((RiscvInstId::FCVT_D_L, 4)),
+        0x03 => Some((RiscvInstId::FCVT_D_LU, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_11110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_11110(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FMV_W_X, 4)),
-        0x01 => 
-        Some((RiscvInstId::FMV_D_X, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FMV_W_X, 4)),
+        0x01 => Some((RiscvInstId::FMV_D_X, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_10100_r3_01000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_10100_r3_01000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
-        Some((RiscvInstId::FCVT_S_D, 4)),
-        0x01 => 
-        Some((RiscvInstId::FCVT_D_S, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::FCVT_S_D, 4)),
+        0x01 => Some((RiscvInstId::FCVT_D_S, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x01 => 
-        Some((RiscvInstId::CSRRW, 4)),
-        0x02 => 
-        Some((RiscvInstId::CSRRS, 4)),
-        0x03 => 
-        Some((RiscvInstId::CSRRC, 4)),
-        0x05 => 
-        Some((RiscvInstId::CSRRWI, 4)),
-        0x06 => 
-        Some((RiscvInstId::CSRRSI, 4)),
-        0x07 => 
-        Some((RiscvInstId::CSRRCI, 4)),
-        0x00 => 
+        0x01 => Some((RiscvInstId::CSRRW, 4)),
+        0x02 => Some((RiscvInstId::CSRRS, 4)),
+        0x03 => Some((RiscvInstId::CSRRC, 4)),
+        0x05 => Some((RiscvInstId::CSRRWI, 4)),
+        0x06 => Some((RiscvInstId::CSRRSI, 4)),
+        0x07 => Some((RiscvInstId::CSRRCI, 4)),
+        0x00 =>
         // Remaining Instruction is 10
         // ecall
         // ebreak
@@ -1394,156 +1387,162 @@ fn decode_inst_ld_11_op_11100 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // mrth
         // wfi
         // sfence.vma r[19:15],r[24:20]
-        decode_inst_ld_11_op_11100_f3_000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_11100_f3_000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // ecall
         // ebreak
         // uret
-        decode_inst_ld_11_op_11100_f3_000_r3_00000 (inst),
-        0x02 => 
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00000(inst)
+        }
+        0x02 =>
         // Remaining Instruction is 3
         // sret
         // wfi
         // sfence.vma r[19:15],r[24:20]
-        decode_inst_ld_11_op_11100_f3_000_r3_00010 (inst),
-        0x04 => 
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00010(inst)
+        }
+        0x04 =>
         // Remaining Instruction is 2
         // hret
         // mrth
-        decode_inst_ld_11_op_11100_f3_000_r3_00100 (inst),
-        0x06 => 
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00100(inst)
+        }
+        0x06 =>
         // Remaining Instruction is 2
         // mret
         // mrts
-        decode_inst_ld_11_op_11100_f3_000_r3_00110 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00110(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // ecall
         // ebreak
         // uret
-        decode_inst_ld_11_op_11100_f3_000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 => 
-        Some((RiscvInstId::ECALL, 4)),
-        0x01 => 
-        Some((RiscvInstId::EBREAK, 4)),
-        0x02 => 
-        Some((RiscvInstId::URET, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::ECALL, 4)),
+        0x01 => Some((RiscvInstId::EBREAK, 4)),
+        0x02 => Some((RiscvInstId::URET, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // sret
         // wfi
-        decode_inst_ld_11_op_11100_f3_000_r3_00010_f2_00 (inst),
-        0x01 => 
-        Some((RiscvInstId::SFENCE_VMA, 4)),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00010_f2_00(inst)
+        }
+        0x01 => Some((RiscvInstId::SFENCE_VMA, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00010_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00010_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x02 => 
-        Some((RiscvInstId::SRET, 4)),
-        0x05 => 
-        Some((RiscvInstId::WFI, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::SRET, 4)),
+        0x05 => Some((RiscvInstId::WFI, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // hret
         // mrth
-        decode_inst_ld_11_op_11100_f3_000_r3_00100_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00100_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00100_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00100_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x02 => 
-        Some((RiscvInstId::HRET, 4)),
-        0x06 => 
-        Some((RiscvInstId::MRTH, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::HRET, 4)),
+        0x06 => Some((RiscvInstId::MRTH, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00110(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // mret
         // mrts
-        decode_inst_ld_11_op_11100_f3_000_r3_00110_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_11100_f3_000_r3_00110_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_11100_f3_000_r3_00110_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_11100_f3_000_r3_00110_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x02 => 
-        Some((RiscvInstId::MRET, 4)),
-        0x05 => 
-        Some((RiscvInstId::MRTS, 4)),
-      _ => None,
-    }
+        0x02 => Some((RiscvInstId::MRET, 4)),
+        0x05 => Some((RiscvInstId::MRTS, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00110(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::ADDIW, 4)),
-        0x01 => 
-        Some((RiscvInstId::SLLIW, 4)),
-        0x05 => 
+        0x00 => Some((RiscvInstId::ADDIW, 4)),
+        0x01 => Some((RiscvInstId::SLLIW, 4)),
+        0x05 =>
         // Remaining Instruction is 2
         // srliw      r[11:7],r[19:15],r[24:20]
         // sraiw      r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_00110_f3_101 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_00110_f3_101(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_00110_f3_101 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_00110_f3_101(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 => 
-        Some((RiscvInstId::SRLIW, 4)),
-        0x08 => 
-        Some((RiscvInstId::SRAIW, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::SRLIW, 4)),
+        0x08 => Some((RiscvInstId::SRAIW, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01110(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 8
         // addw       r[11:7],r[19:15],r[24:20]
         // sllw       r[11:7],r[19:15],r[24:20]
@@ -1553,88 +1552,90 @@ fn decode_inst_ld_11_op_01110 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // divuw      r[11:7],r[19:15],r[24:20]
         // remw       r[11:7],r[19:15],r[24:20]
         // remuw      r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01110_r3_00000 (inst),
-        0x08 => 
+        {
+            decode_inst_ld_11_op_01110_r3_00000(inst)
+        }
+        0x08 =>
         // Remaining Instruction is 2
         // subw       r[11:7],r[19:15],r[24:20]
         // sraw       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01110_r3_01000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01110_r3_01000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01110_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01110_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // addw       r[11:7],r[19:15],r[24:20]
         // sllw       r[11:7],r[19:15],r[24:20]
         // srlw       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01110_r3_00000_f2_00 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_11_op_01110_r3_00000_f2_00(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 5
         // mulw       r[11:7],r[19:15],r[24:20]
         // divw       r[11:7],r[19:15],r[24:20]
         // divuw      r[11:7],r[19:15],r[24:20]
         // remw       r[11:7],r[19:15],r[24:20]
         // remuw      r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01110_r3_00000_f2_01 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01110_r3_00000_f2_01(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01110_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01110_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::ADDW, 4)),
-        0x01 => 
-        Some((RiscvInstId::SLLW, 4)),
-        0x05 => 
-        Some((RiscvInstId::SRLW, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::ADDW, 4)),
+        0x01 => Some((RiscvInstId::SLLW, 4)),
+        0x05 => Some((RiscvInstId::SRLW, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01110_r3_00000_f2_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01110_r3_00000_f2_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::MULW, 4)),
-        0x04 => 
-        Some((RiscvInstId::DIVW, 4)),
-        0x05 => 
-        Some((RiscvInstId::DIVUW, 4)),
-        0x06 => 
-        Some((RiscvInstId::REMW, 4)),
-        0x07 => 
-        Some((RiscvInstId::REMUW, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::MULW, 4)),
+        0x04 => Some((RiscvInstId::DIVW, 4)),
+        0x05 => Some((RiscvInstId::DIVUW, 4)),
+        0x06 => Some((RiscvInstId::REMW, 4)),
+        0x07 => Some((RiscvInstId::REMUW, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01110_r3_01000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01110_r3_01000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // subw       r[11:7],r[19:15],r[24:20]
         // sraw       r[11:7],r[19:15],r[24:20]
-        decode_inst_ld_11_op_01110_r3_01000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_11_op_01110_r3_01000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_11_op_01110_r3_01000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_11_op_01110_r3_01000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
-        Some((RiscvInstId::SUBW, 4)),
-        0x05 => 
-        Some((RiscvInstId::SRAW, 4)),
-      _ => None,
-    }
+        0x00 => Some((RiscvInstId::SUBW, 4)),
+        0x05 => Some((RiscvInstId::SRAW, 4)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 9
         // c.addi4spn cr[4:2],u[12:5]
         // c.fld      cf[4:2],cr[9:7],u[6:5]|u[12:10]<<3
@@ -1645,11 +1646,13 @@ fn decode_inst_ld_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.sw       cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
@@ -1663,14 +1666,18 @@ fn decode_inst_ld_00_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.sw       cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 9
         // c.addi4spn cr[4:2],u[12:5]
         // c.fld      cf[4:2],cr[9:7],u[6:5]|u[12:10]<<3
@@ -1681,60 +1688,75 @@ fn decode_inst_ld_00_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> 
         // c.sw       cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e =>
         // Remaining Instruction is 5
         // c.addi4spn cr[4:2],u[12:5]
         // c.fld      cf[4:2],cr[9:7],u[6:5]|u[12:10]<<3
         // c.lw       cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.flw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.ld       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000 (inst),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000(inst)
+        }
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f =>
         // Remaining Instruction is 4
         // c.fsd      cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
         // c.sw       cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 | 0x01 =>
-        Some((RiscvInstId::C_ADDI4SPN, 2)),
-        0x02 | 0x03 =>
-        Some((RiscvInstId::C_FLD, 2)),
-        0x04 | 0x05 =>
-        Some((RiscvInstId::C_LW, 2)),
+        0x00 | 0x01 => Some((RiscvInstId::C_ADDI4SPN, 2)),
+        0x02 | 0x03 => Some((RiscvInstId::C_FLD, 2)),
+        0x04 | 0x05 => Some((RiscvInstId::C_LW, 2)),
         0x06 | 0x07 =>
         // Remaining Instruction is 2
         // c.flw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.ld       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.flw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.ld       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
         0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
@@ -1743,35 +1765,43 @@ fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000 (inst: u32
         // c.ld       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
         riscv_decoder_extra::decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000_op_00000 (inst),
       _ => None,
-    }
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x02 | 0x03 =>
-        Some((RiscvInstId::C_FSD, 2)),
-        0x04 | 0x05 =>
-        Some((RiscvInstId::C_SW, 2)),
+        0x02 | 0x03 => Some((RiscvInstId::C_FSD, 2)),
+        0x04 | 0x05 => Some((RiscvInstId::C_SW, 2)),
         0x06 | 0x07 =>
         // Remaining Instruction is 2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.fsw      cr[4:2],cr[9:7],u[5:5]|u[12:10]|u[6:6]<<2
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
-        decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
         0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
@@ -1780,14 +1810,14 @@ fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000 (inst: u32
         // c.sd       cr[4:2],cr[9:7],u[6:5]|u[12:10]<<3
         riscv_decoder_extra::decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000_op_00000 (inst),
       _ => None,
-    }
+    };
 }
-fn decode_inst_ld_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 9
-        // c.nop     
+        // c.nop
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli     cr[9:7],u[12:12]|h[6:2]
         // c.srai     cr[9:7],u[12:12]|h[6:2]
@@ -1796,8 +1826,10 @@ fn decode_inst_ld_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.xor      cr[9:7],cr[4:2]
         // c.or       cr[9:7],cr[4:2]
         // c.and      cr[9:7],cr[4:2]
-        decode_inst_ld_01_f3_000 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_01_f3_000(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 6
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli64   cr[9:7],u[12:12]|h[6:2]
@@ -1805,50 +1837,66 @@ fn decode_inst_ld_01 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.andi     cr[9:7],u[12:12]|h[6:2]
         // c.subw     cr[9:7],r[6:2]
         // c.addw     cr[9:7],r[6:2]
-        decode_inst_ld_01_f3_001 (inst),
+        {
+            decode_inst_ld_01_f3_001(inst)
+        }
         0x02 | 0x03 =>
         // Remaining Instruction is 3
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
         // c.j        u[12:12]|u[8:8]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
-        decode_inst_ld_01_f3_010 (inst),
+        {
+            decode_inst_ld_01_f3_010(inst)
+        }
         0x04 | 0x05 =>
         // Remaining Instruction is 2
         // c.li       r[11:7],u[12:12]|h[6:2]
         // c.beqz     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_100 (inst),
+        {
+            decode_inst_ld_01_f3_100(inst)
+        }
         0x06 | 0x07 =>
         // Remaining Instruction is 3
         // c.addi16sp cr[4:2],u[12:5]
         // c.lui      r[11:7],u[12:12]|h[6:2]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
-        // c.nop     
+        // c.nop
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00000 (inst),
+        {
+            decode_inst_ld_01_f3_000_rd_00000(inst)
+        }
         0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00001 (inst),
+        {
+            decode_inst_ld_01_f3_000_rd_00001(inst)
+        }
         0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srai     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_01000 (inst),
+        {
+            decode_inst_ld_01_f3_000_rd_01000(inst)
+        }
         0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.andi     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_10000 (inst),
+        {
+            decode_inst_ld_01_f3_000_rd_10000(inst)
+        }
         0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 5
         // c.addi     r[11:7],u[12:12]|u[6:2]
@@ -1856,210 +1904,269 @@ fn decode_inst_ld_01_f3_000 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.xor      cr[9:7],cr[4:2]
         // c.or       cr[9:7],cr[4:2]
         // c.and      cr[9:7],cr[4:2]
-        decode_inst_ld_01_f3_000_rd_11000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_11000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
-        // c.nop     
+        // c.nop
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00000_op_00000 (inst),
-        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
-        Some((RiscvInstId::C_SRLI, 2)),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00000_op_00000(inst)
+        }
+        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c
+        | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18
+        | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f => Some((RiscvInstId::C_SRLI, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00000_op_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00000_op_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
-        // c.nop     
+        // c.nop
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
-        // c.nop     
+        // c.nop
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
-        // c.nop     
+        // c.nop
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00000_op_00000_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_NOP, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_SRLI, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_NOP, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_SRLI, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00001_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00001_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00001_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00001_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_00001_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_ADDI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_SRLI, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_ADDI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_SRLI, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_01000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_01000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srai     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_01000_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_01000_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_01000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_01000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srai     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srai     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_01000_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_ADDI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_SRAI, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_ADDI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_SRAI, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_10000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_10000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.andi     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_10000_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_10000_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_10000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_10000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.andi     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.andi     cr[9:7],u[12:12]|h[6:2]
-        decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_10000_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_ADDI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_ANDI, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_ADDI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_ANDI, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_11000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_11000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 5
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.sub      cr[9:7],cr[4:2]
         // c.xor      cr[9:7],cr[4:2]
         // c.or       cr[9:7],cr[4:2]
         // c.and      cr[9:7],cr[4:2]
-        decode_inst_ld_01_f3_000_rd_11000_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_11000_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_11000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_11000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
@@ -2069,57 +2176,68 @@ fn decode_inst_ld_01_f3_000_rd_11000_r3_00000 (inst: u32) -> Option<(RiscvInstId
         // c.xor      cr[9:7],cr[4:2]
         // c.or       cr[9:7],cr[4:2]
         // c.and      cr[9:7],cr[4:2]
-        decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 5
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.sub      cr[9:7],cr[4:2]
         // c.xor      cr[9:7],cr[4:2]
         // c.or       cr[9:7],cr[4:2]
         // c.and      cr[9:7],cr[4:2]
-        decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_ADDI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_ADDI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f =>
         // Remaining Instruction is 4
         // c.sub      cr[9:7],cr[4:2]
         // c.xor      cr[9:7],cr[4:2]
         // c.or       cr[9:7],cr[4:2]
         // c.and      cr[9:7],cr[4:2]
-        decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000_r1_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000_r1_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000_r1_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_000_rd_11000_r3_00000_f2_00_r2_00000_r1_00001(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 =>
-        Some((RiscvInstId::C_SUB, 2)),
-        0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f =>
-        Some((RiscvInstId::C_XOR, 2)),
-        0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 =>
-        Some((RiscvInstId::C_OR, 2)),
-        0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
-        Some((RiscvInstId::C_AND, 2)),
-      _ => None,
-    }
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 => Some((RiscvInstId::C_SUB, 2)),
+        0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f => Some((RiscvInstId::C_XOR, 2)),
+        0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 => Some((RiscvInstId::C_OR, 2)),
+        0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f => Some((RiscvInstId::C_AND, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 6
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli64   cr[9:7],u[12:12]|h[6:2]
@@ -2127,11 +2245,13 @@ fn decode_inst_ld_01_f3_001 (inst: u32) -> Option<(RiscvInstId, usize)> {
         // c.andi     cr[9:7],u[12:12]|h[6:2]
         // c.subw     cr[9:7],r[6:2]
         // c.addw     cr[9:7],r[6:2]
-        decode_inst_ld_01_f3_001_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_001_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_001_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_001_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
@@ -2142,14 +2262,18 @@ fn decode_inst_ld_01_f3_001_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)>
         // c.andi     cr[9:7],u[12:12]|h[6:2]
         // c.subw     cr[9:7],r[6:2]
         // c.addw     cr[9:7],r[6:2]
-        decode_inst_ld_01_f3_001_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_001_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_001_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_001_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 6
         // c.addi     r[11:7],u[12:12]|u[6:2]
         // c.srli64   cr[9:7],u[12:12]|h[6:2]
@@ -2157,66 +2281,76 @@ fn decode_inst_ld_01_f3_001_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, u
         // c.andi     cr[9:7],u[12:12]|h[6:2]
         // c.subw     cr[9:7],r[6:2]
         // c.addw     cr[9:7],r[6:2]
-        decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_ADDI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_ADDI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f =>
         // Remaining Instruction is 5
         // c.srli64   cr[9:7],u[12:12]|h[6:2]
         // c.srai64   cr[9:7],u[12:12]|h[6:2]
         // c.andi     cr[9:7],u[12:12]|h[6:2]
         // c.subw     cr[9:7],r[6:2]
         // c.addw     cr[9:7],r[6:2]
-        decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 =>
-        Some((RiscvInstId::C_SRLI64, 2)),
-        0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f =>
-        Some((RiscvInstId::C_SRAI64, 2)),
-        0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 =>
-        Some((RiscvInstId::C_ANDI, 2)),
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 => Some((RiscvInstId::C_SRLI64, 2)),
+        0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f => Some((RiscvInstId::C_SRAI64, 2)),
+        0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 => Some((RiscvInstId::C_ANDI, 2)),
         0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.subw     cr[9:7],r[6:2]
         // c.addw     cr[9:7],r[6:2]
-        decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001_rd_11000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001_rd_11000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001_rd_11000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_001_r3_00000_f2_00_r2_00000_r1_00001_rd_11000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 =>
-        Some((RiscvInstId::C_SUBW, 2)),
-        0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f =>
-        Some((RiscvInstId::C_ADDW, 2)),
-      _ => None,
-    }
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 => Some((RiscvInstId::C_SUBW, 2)),
+        0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f => Some((RiscvInstId::C_ADDW, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 3
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
         // c.j        u[12:12]|u[8:8]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
-        decode_inst_ld_01_f3_010_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_010_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_010_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_010_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
@@ -2224,47 +2358,64 @@ fn decode_inst_ld_01_f3_010_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)>
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
         // c.j        u[12:12]|u[8:8]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
-        decode_inst_ld_01_f3_010_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_010_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_010_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_010_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 3
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
         // c.j        u[12:12]|u[8:8]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
-        decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e =>
         // Remaining Instruction is 2
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
-        decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000 (inst),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_J, 2)),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000(inst)
+        }
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_J, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.jal      u[12:12]|u[7:7]|u[10:9]|u[6:6]|u[7:7]|u[2:2]|u[11:11]|u[5:3]<<1
         // c.addiw    r[11:7],h[12:12]|h[6:2]
-        decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
         0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
@@ -2273,507 +2424,646 @@ fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000 (inst: u32
         // c.addiw    r[11:7],h[12:12]|h[6:2]
         riscv_decoder_extra::decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000_op_00000 (inst),
       _ => None,
-    }
+    };
 }
-fn decode_inst_ld_01_f3_100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.li       r[11:7],u[12:12]|h[6:2]
         // c.beqz     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_100_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_100_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_100_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_100_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.li       r[11:7],u[12:12]|h[6:2]
         // c.beqz     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_100_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_100_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_100_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_100_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.li       r[11:7],u[12:12]|h[6:2]
         // c.beqz     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_100_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_100_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_100_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_100_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_LI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_BEQZ, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_LI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_BEQZ, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x02 => 
+        0x02 =>
         // Remaining Instruction is 2
         // c.addi16sp cr[4:2],u[12:5]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00010 (inst),
-        0x00 | 0x01 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        {
+            decode_inst_ld_01_f3_110_rd_00010(inst)
+        }
+        0x00 | 0x01 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c
+        | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18
+        | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.lui      r[11:7],u[12:12]|h[6:2]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi16sp cr[4:2],u[12:5]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00010_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00010_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00010_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00010_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.addi16sp cr[4:2],u[12:5]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.addi16sp cr[4:2],u[12:5]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00010_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_ADDI16SP, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_BNEZ, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_ADDI16SP, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_BNEZ, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.lui      r[11:7],u[12:12]|h[6:2]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00000_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00000_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.lui      r[11:7],u[12:12]|h[6:2]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.lui      r[11:7],u[12:12]|h[6:2]
         // c.bnez     cr[9:7],u[12:12]|u[6:5]|u[2:2]|u[11:10]|u[4:3]<<1
-        decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_01_f3_110_rd_00000_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_LUI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_BNEZ, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_LUI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_BNEZ, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f3 = ((inst as u64) >> 12) & (((1 as u64) << 3) - 1);
     return match field_f3 {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jr       r[11:7]
         // c.mv       r[11:7],r[6:2]
-        decode_inst_ld_10_f3_000 (inst),
-        0x01 => 
+        {
+            decode_inst_ld_10_f3_000(inst)
+        }
+        0x01 =>
         // Remaining Instruction is 4
         // c.slli     r[11:7],u[12:12]|u[6:2]
-        // c.ebreak  
+        // c.ebreak
         // c.jalr     r[11:7]
         // c.add      r[11:7],r[6:2]
-        decode_inst_ld_10_f3_001 (inst),
+        {
+            decode_inst_ld_10_f3_001(inst)
+        }
         0x02 | 0x03 =>
         // Remaining Instruction is 2
-        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3 
+        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fsdsp    f[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_010 (inst),
+        {
+            decode_inst_ld_10_f3_010(inst)
+        }
         0x04 | 0x05 =>
         // Remaining Instruction is 2
         // c.lwsp     r[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.swsp     r[6:2],u[8:7]|u[12:9]<<2
-        decode_inst_ld_10_f3_100 (inst),
+        {
+            decode_inst_ld_10_f3_100(inst)
+        }
         0x06 | 0x07 =>
         // Remaining Instruction is 4
         // c.flwsp    f[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_110 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jr       r[11:7]
-        decode_inst_ld_10_f3_000_op_00000 (inst),
-        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        {
+            decode_inst_ld_10_f3_000_op_00000(inst)
+        }
+        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c
+        | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18
+        | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.mv       r[11:7],r[6:2]
-        decode_inst_ld_10_f3_000_op_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jr       r[11:7]
-        decode_inst_ld_10_f3_000_op_00000_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00000_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00000_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00000_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jr       r[11:7]
-        decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jr       r[11:7]
-        decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00000_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_SLLI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_JR, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_SLLI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_JR, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.mv       r[11:7],r[6:2]
-        decode_inst_ld_10_f3_000_op_00001_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00001_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00001_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00001_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.mv       r[11:7],r[6:2]
-        decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.mv       r[11:7],r[6:2]
-        decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_000_op_00001_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_SLLI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_MV, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_SLLI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_MV, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
-        0x00 => 
+        0x00 =>
         // Remaining Instruction is 3
         // c.slli     r[11:7],u[12:12]|u[6:2]
-        // c.ebreak  
+        // c.ebreak
         // c.jalr     r[11:7]
-        decode_inst_ld_10_f3_001_op_00000 (inst),
-        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        {
+            decode_inst_ld_10_f3_001_op_00000(inst)
+        }
+        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c
+        | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18
+        | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.add      r[11:7],r[6:2]
-        decode_inst_ld_10_f3_001_op_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c
+        | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18
+        | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jalr     r[11:7]
-        decode_inst_ld_10_f3_001_op_00000_rd_00001 (inst),
-        0x00 => 
-        Some((RiscvInstId::C_EBREAK, 2)),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00000_rd_00001(inst)
+        }
+        0x00 => Some((RiscvInstId::C_EBREAK, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00000_rd_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00000_rd_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jalr     r[11:7]
-        decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jalr     r[11:7]
-        decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.jalr     r[11:7]
-        decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00000_rd_00001_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_SLLI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_JALR, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_SLLI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_JALR, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00001(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.add      r[11:7],r[6:2]
-        decode_inst_ld_10_f3_001_op_00001_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00001_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00001_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00001_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.add      r[11:7],r[6:2]
-        decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.slli     r[11:7],u[12:12]|u[6:2]
         // c.add      r[11:7],r[6:2]
-        decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_001_op_00001_r3_00000_f2_00_r2_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_SLLI, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_ADD, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_SLLI, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_ADD, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_010 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_010(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
-        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3 
+        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fsdsp    f[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_010_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_010_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_010_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_010_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
-        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3 
+        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fsdsp    f[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_010_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_010_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_010_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_010_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
-        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3 
+        // c.fldsp    r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fsdsp    f[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_010_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_010_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_010_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_010_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_FLDSP, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_FSDSP, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_FLDSP, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_FSDSP, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_100 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_100(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.lwsp     r[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.swsp     r[6:2],u[8:7]|u[12:9]<<2
-        decode_inst_ld_10_f3_100_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_100_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_100_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_100_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
         // Remaining Instruction is 2
         // c.lwsp     r[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.swsp     r[6:2],u[8:7]|u[12:9]<<2
-        decode_inst_ld_10_f3_100_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_100_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_100_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_100_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.lwsp     r[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.swsp     r[6:2],u[8:7]|u[12:9]<<2
-        decode_inst_ld_10_f3_100_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_100_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_100_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_100_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
-        Some((RiscvInstId::C_LWSP, 2)),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
-        Some((RiscvInstId::C_SWSP, 2)),
-      _ => None,
-    }
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e => Some((RiscvInstId::C_LWSP, 2)),
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f => Some((RiscvInstId::C_SWSP, 2)),
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r3 = ((inst as u64) >> 27) & (((1 as u64) << 5) - 1);
     return match field_r3 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 4
         // c.flwsp    f[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_110_r3_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110_r3_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_f2 = ((inst as u64) >> 25) & (((1 as u64) << 2) - 1);
     return match field_f2 {
         0x00 | 0x01 | 0x02 | 0x03 =>
@@ -2782,53 +3072,72 @@ fn decode_inst_ld_10_f3_110_r3_00000 (inst: u32) -> Option<(RiscvInstId, usize)>
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_110_r3_00000_f2_00 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110_r3_00000_f2_00(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000_f2_00 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000_f2_00(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r2 = ((inst as u64) >> 20) & (((1 as u64) << 5) - 1);
     return match field_r2 {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 4
         // c.flwsp    f[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000(inst: u32) -> Option<(RiscvInstId, usize)> {
     let field_r1 = ((inst as u64) >> 15) & (((1 as u64) << 5) - 1);
     return match field_r1 {
-        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16 | 0x18 | 0x1a | 0x1c | 0x1e =>
+        0x00 | 0x02 | 0x04 | 0x06 | 0x08 | 0x0a | 0x0c | 0x0e | 0x10 | 0x12 | 0x14 | 0x16
+        | 0x18 | 0x1a | 0x1c | 0x1e =>
         // Remaining Instruction is 2
         // c.flwsp    f[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
-        decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000 (inst),
-        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17 | 0x19 | 0x1b | 0x1d | 0x1f =>
+        {
+            decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000(inst)
+        }
+        0x01 | 0x03 | 0x05 | 0x07 | 0x09 | 0x0b | 0x0d | 0x0f | 0x11 | 0x13 | 0x15 | 0x17
+        | 0x19 | 0x1b | 0x1d | 0x1f =>
         // Remaining Instruction is 2
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 => 
-        Some((RiscvInstId::C_FLWSP, 2)),
-        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 => Some((RiscvInstId::C_FLWSP, 2)),
+        0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c
+        | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18
+        | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.flwsp    f[11:7],u[3:2]|u[12:12]|u[6:4]<<2
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
-        decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
         0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
@@ -2837,20 +3146,28 @@ fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001 (inst: u32
         // c.ldsp     r[11:7],u[4:2]|u[12:12]|u[6:5]<<3
         riscv_decoder_extra::decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001_op_00000 (inst),
       _ => None,
-    }
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_rd = ((inst as u64) >> 7) & (((1 as u64) << 5) - 1);
     return match field_rd {
-        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
+        0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b
+        | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17
+        | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
         // Remaining Instruction is 2
         // c.fswsp    f[6:2],u[9:7]|u[12:10]<<3
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
-        decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000 (inst),
-      _ => None,
-    }
+        {
+            decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000(inst)
+        }
+        _ => None,
+    };
 }
-fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000 (inst: u32) -> Option<(RiscvInstId, usize)> {
+fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000(
+    inst: u32,
+) -> Option<(RiscvInstId, usize)> {
     let field_op = ((inst as u64) >> 2) & (((1 as u64) << 5) - 1);
     return match field_op {
         0x00 | 0x01 | 0x02 | 0x03 | 0x04 | 0x05 | 0x06 | 0x07 | 0x08 | 0x09 | 0x0a | 0x0b | 0x0c | 0x0d | 0x0e | 0x0f | 0x10 | 0x11 | 0x12 | 0x13 | 0x14 | 0x15 | 0x16 | 0x17 | 0x18 | 0x19 | 0x1a | 0x1b | 0x1c | 0x1d | 0x1e | 0x1f =>
@@ -2859,5 +3176,5 @@ fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000 (inst: u32
         // c.sdsp     r[6:2],u[9:7]|u[12:10]<<3
         riscv_decoder_extra::decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000_op_00000 (inst),
       _ => None,
-    }
+    };
 }

--- a/src/target/riscv/riscv_decoder_extra.rs
+++ b/src/target/riscv/riscv_decoder_extra.rs
@@ -1,60 +1,61 @@
 use super::riscv_inst_id::RiscvInstId;
 
-pub fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001_op_00000 (_inst: u32) -> Option<(RiscvInstId, usize)> {
-  // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
-  //   return Some((RiscvInstId::C_FLWSP;
-  // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
+pub fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00000_rd_00001_op_00000(
+    _inst: u32,
+) -> Option<(RiscvInstId, usize)> {
+    // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
+    //   return Some((RiscvInstId::C_FLWSP;
+    // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
     return Some((RiscvInstId::C_LDSP, 2));
-  // } else {
-  //   return Some((RiscvInstId::SENTINEL_MAX;
-  // }
-
+    // } else {
+    //   return Some((RiscvInstId::SENTINEL_MAX;
+    // }
 }
 
-
-pub fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000_op_00000 (_inst: u32) -> Option<(RiscvInstId, usize)> {
-  // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
-  //   return Some((RiscvInstId::C_FSWSP;
-  // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
+pub fn decode_inst_ld_10_f3_110_r3_00000_f2_00_r2_00000_r1_00001_rd_00000_op_00000(
+    _inst: u32,
+) -> Option<(RiscvInstId, usize)> {
+    // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
+    //   return Some((RiscvInstId::C_FSWSP;
+    // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
     return Some((RiscvInstId::C_SDSP, 2));
-  // } else {
-  //   return Some((RiscvInstId::SENTINEL_MAX;
-  // }
-
+    // } else {
+    //   return Some((RiscvInstId::SENTINEL_MAX;
+    // }
 }
 
-
-pub fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000_op_00000 (_inst: u32) -> Option<(RiscvInstId, usize)> {
-  // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
-  //   return Some((RiscvInstId::C_FLW;
-  // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
+pub fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00000_f3_110_rd_00000_op_00000(
+    _inst: u32,
+) -> Option<(RiscvInstId, usize)> {
+    // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
+    //   return Some((RiscvInstId::C_FLW;
+    // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
     return Some((RiscvInstId::C_LD, 2));
-  // } else {
-  //   return Some((RiscvInstId::SENTINEL_MAX;
-  // }
-
+    // } else {
+    //   return Some((RiscvInstId::SENTINEL_MAX;
+    // }
 }
 
-
-pub fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000_op_00000 (_inst: u32) -> Option<(RiscvInstId, usize)> {
-  // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
-  //   return Some((RiscvInstId::C_FSW;
-  // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
+pub fn decode_inst_ld_00_r3_00000_f2_00_r2_00000_r1_00001_f3_110_rd_00000_op_00000(
+    _inst: u32,
+) -> Option<(RiscvInstId, usize)> {
+    // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
+    //   return Some((RiscvInstId::C_FSW;
+    // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
     return Some((RiscvInstId::C_SD, 2));
-  // } else {
-  //   return Some((RiscvInstId::SENTINEL_MAX;
-  // }
-
+    // } else {
+    //   return Some((RiscvInstId::SENTINEL_MAX;
+    // }
 }
 
-
-pub fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000_op_00000 (_inst: u32) -> Option<(RiscvInstId, usize)> {
-  // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
-  //   return Some((RiscvInstId::C_JAL;
-  // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
+pub fn decode_inst_ld_01_f3_010_r3_00000_f2_00_r2_00000_r1_00000_rd_00000_op_00000(
+    _inst: u32,
+) -> Option<(RiscvInstId, usize)> {
+    // if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit32) {
+    //   return Some((RiscvInstId::C_JAL;
+    // } else if (m_pe_thread->GetBitMode() == RiscvBitMode_t::Bit64) {
     return Some((RiscvInstId::C_ADDIW, 2));
-  // } else {
-  //   return Some((RiscvInstId::SENTINEL_MAX;
-  // }
-
+    // } else {
+    //   return Some((RiscvInstId::SENTINEL_MAX;
+    // }
 }

--- a/src/target/riscv/riscv_disassemble.rs
+++ b/src/target/riscv/riscv_disassemble.rs
@@ -1,4 +1,4 @@
-use spike_dasm_wrapper::{Disasm};
+use spike_dasm_wrapper::Disasm;
 
 pub fn disassemble_riscv(inst: u32) -> String {
     let mut disasm = Disasm::new();

--- a/src/target/riscv/riscv_inst_id.rs
+++ b/src/target/riscv/riscv_inst_id.rs
@@ -1,6 +1,5 @@
 /* CAUTION! THIS SOURCE CODE IS GENERATED AUTOMATICALLY. DON'T MODIFY BY HAND. */
 
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 #[allow(non_camel_case_types)]
 pub enum RiscvInstId {

--- a/src/target/riscv/translate_riscv_c.rs
+++ b/src/target/riscv/translate_riscv_c.rs
@@ -1,39 +1,41 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::super::super::tcg::tcg::{TCGOp, TCGOpcode, TCGv, TCGLabel};
 use super::super::super::instr_info::InstrInfo;
-use super::riscv::{CALL_HELPER_IDX};
+use super::super::super::tcg::tcg::{TCGLabel, TCGOp, TCGOpcode, TCGv};
+use super::riscv::CALL_HELPER_IDX;
 
 use super::riscv::TranslateRiscv;
 
 #[macro_export]
 macro_rules! get_nzuimm {
     ($inst:expr) => {
-        ((($inst as u64 >> 11) & 0x3) << 4) |
-        ((($inst as u64 >>  7) & 0xf) << 6) |
-        ((($inst as u64 >>  6) & 0x1) << 2) |
-        ((($inst as u64 >>  5) & 0x1) << 3)
+        ((($inst as u64 >> 11) & 0x3) << 4)
+            | ((($inst as u64 >> 7) & 0xf) << 6)
+            | ((($inst as u64 >> 6) & 0x1) << 2)
+            | ((($inst as u64 >> 5) & 0x1) << 3)
     };
 }
 
 #[macro_export]
 macro_rules! get_nzimm {
     ($inst:expr) => {
-        extend_sign(((($inst as u64 >> 12) &  0x1) << 5) |
-                    ((($inst as u64 >>  2) & 0x1f) << 0), 5)
+        extend_sign(
+            ((($inst as u64 >> 12) & 0x1) << 5) | ((($inst as u64 >> 2) & 0x1f) << 0),
+            5,
+        )
     };
 }
-
 
 #[macro_export]
 macro_rules! get_nzimm_lui {
     ($inst:expr) => {
-        extend_sign(((($inst as u64 >> 12) &  0x1) << 17) |
-                    ((($inst as u64 >>  2) & 0x1f) << 12), 17)
+        extend_sign(
+            ((($inst as u64 >> 12) & 0x1) << 17) | ((($inst as u64 >> 2) & 0x1f) << 12),
+            17,
+        )
     };
 }
-
 
 macro_rules! get_c_reg_addr {
     ($c_reg_addr:expr) => {
@@ -46,36 +48,37 @@ macro_rules! get_c_reg_addr {
             5 => 13, // x13, f13
             6 => 14, // x14, f14
             7 => 15, // x15, f15
-            _ => panic!("Not covered")
+            _ => panic!("Not covered"),
         }
-    }
+    };
 }
 
 macro_rules! get_nzimm_addi16sp {
     ($inst: expr) => {
-        extend_sign(((((($inst >>12) & 0x1) << 5) |
-                      ((($inst >> 3) & 0x3) << 3) |
-                      ((($inst >> 5) & 0x1) << 2) |
-                      ((($inst >> 2) & 0x1) << 1) |
-                      ((($inst >> 6) & 0x1) << 0)) << 4) as u64, 9)
-    }
+        extend_sign(
+            ((((($inst >> 12) & 0x1) << 5)
+                | ((($inst >> 3) & 0x3) << 3)
+                | ((($inst >> 5) & 0x1) << 2)
+                | ((($inst >> 2) & 0x1) << 1)
+                | ((($inst >> 6) & 0x1) << 0))
+                << 4) as u64,
+            9,
+        )
+    };
 }
-
 
 #[inline]
-fn extend_sign(data: u64, msb: usize) -> i64
-{
-  let mask = 1 << msb; // mask can be pre-computed if b is fixed
-  let data = data & ((1 << (msb + 1)) - 1);  // (Skip this if bits in x above position b are already zero.)
-  
-  ((data ^ mask).wrapping_sub(mask)) as i64
-}
+fn extend_sign(data: u64, msb: usize) -> i64 {
+    let mask = 1 << msb; // mask can be pre-computed if b is fixed
+    let data = data & ((1 << (msb + 1)) - 1); // (Skip this if bits in x above position b are already zero.)
 
+    ((data ^ mask).wrapping_sub(mask)) as i64
+}
 
 impl TranslateRiscv {
     pub fn translate_c_addi4spn(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const: u64 = get_nzuimm!(inst.inst as i32);
-        let rs1_addr= 2;  // sp
+        let rs1_addr = 2; // sp
         let rd_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
@@ -87,210 +90,309 @@ impl TranslateRiscv {
         let source1 = self.tcg_temp_new();
 
         tcg_lists.push(TCGOp::tcg_get_gpr(source1, rs1_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, source1, source1, TCGv::new_imm(imm_const)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(imm_const),
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
 
         self.tcg_temp_free(source1);
         tcg_lists
     }
 
-    pub fn translate_c_fld  (&mut self, __inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_lw   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = extend_sign((((((inst.inst >> 10) & 0x7) << 3) |
-                                (((inst.inst >>  6) & 0x1) << 2) |
-                                (((inst.inst >>  5) & 0x1) << 6))) as u64, 6);
+    pub fn translate_c_fld(&mut self, __inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_lw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = extend_sign(
+            ((((inst.inst >> 10) & 0x7) << 3)
+                | (((inst.inst >> 6) & 0x1) << 2)
+                | (((inst.inst >> 5) & 0x1) << 6)) as u64,
+            6,
+        );
 
-        self.translate_raw_load(get_c_reg_addr!((inst.inst >> 7) & 0x7), imm as u64, get_c_reg_addr!((inst.inst >> 2) & 0x7), inst, TCGOpcode::LOAD_32BIT, CALL_HELPER_IDX::CALL_LOAD32_IDX)
+        self.translate_raw_load(
+            get_c_reg_addr!((inst.inst >> 7) & 0x7),
+            imm as u64,
+            get_c_reg_addr!((inst.inst >> 2) & 0x7),
+            inst,
+            TCGOpcode::LOAD_32BIT,
+            CALL_HELPER_IDX::CALL_LOAD32_IDX,
+        )
     }
 
-    pub fn translate_c_flw  (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_ld   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = extend_sign((((((inst.inst >> 10) & 0x7) << 3) |
-                                (((inst.inst >>  5) & 0x3) << 6))) as u64, 6);
-
-        self.translate_raw_load(get_c_reg_addr!((inst.inst >> 7) & 0x7), imm as u64, get_c_reg_addr!((inst.inst >> 2) & 0x7), inst, TCGOpcode::LOAD_64BIT, CALL_HELPER_IDX::CALL_LOAD64_IDX)
+    pub fn translate_c_flw(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
     }
-    pub fn translate_c_fsd  (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_sw   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = extend_sign((((((inst.inst >> 10) & 0x7) << 3) |
-                                (((inst.inst >>  6) & 0x1) << 2) |
-                                (((inst.inst >>  5) & 0x1) << 6))) as u64, 6);
+    pub fn translate_c_ld(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = extend_sign(
+            ((((inst.inst >> 10) & 0x7) << 3) | (((inst.inst >> 5) & 0x3) << 6)) as u64,
+            6,
+        );
 
-        self.translate_raw_store(get_c_reg_addr!((inst.inst >> 7) & 0x7), imm as u64, get_c_reg_addr!((inst.inst >> 2) & 0x7), inst, TCGOpcode::STORE_32BIT, CALL_HELPER_IDX::CALL_STORE32_IDX)
+        self.translate_raw_load(
+            get_c_reg_addr!((inst.inst >> 7) & 0x7),
+            imm as u64,
+            get_c_reg_addr!((inst.inst >> 2) & 0x7),
+            inst,
+            TCGOpcode::LOAD_64BIT,
+            CALL_HELPER_IDX::CALL_LOAD64_IDX,
+        )
+    }
+    pub fn translate_c_fsd(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_sw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = extend_sign(
+            ((((inst.inst >> 10) & 0x7) << 3)
+                | (((inst.inst >> 6) & 0x1) << 2)
+                | (((inst.inst >> 5) & 0x1) << 6)) as u64,
+            6,
+        );
+
+        self.translate_raw_store(
+            get_c_reg_addr!((inst.inst >> 7) & 0x7),
+            imm as u64,
+            get_c_reg_addr!((inst.inst >> 2) & 0x7),
+            inst,
+            TCGOpcode::STORE_32BIT,
+            CALL_HELPER_IDX::CALL_STORE32_IDX,
+        )
     }
 
-    pub fn translate_c_fsw  (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_sd   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = extend_sign((((((inst.inst >> 10) & 0x7) << 3) |
-                                (((inst.inst >>  5) & 0x3) << 6))) as u64, 6);
-
-        self.translate_raw_store(get_c_reg_addr!((inst.inst >> 7) & 0x7), imm as u64, get_c_reg_addr!((inst.inst >> 2) & 0x7), inst, TCGOpcode::STORE_64BIT, CALL_HELPER_IDX::CALL_STORE64_IDX)
+    pub fn translate_c_fsw(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
     }
-    pub fn translate_c_nop  (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_addi (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_sd(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = extend_sign(
+            ((((inst.inst >> 10) & 0x7) << 3) | (((inst.inst >> 5) & 0x3) << 6)) as u64,
+            6,
+        );
+
+        self.translate_raw_store(
+            get_c_reg_addr!((inst.inst >> 7) & 0x7),
+            imm as u64,
+            get_c_reg_addr!((inst.inst >> 2) & 0x7),
+            inst,
+            TCGOpcode::STORE_64BIT,
+            CALL_HELPER_IDX::CALL_STORE64_IDX,
+        )
+    }
+    pub fn translate_c_nop(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_addi(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const = get_nzimm!(inst.inst as i32);
         let rs1_addr = get_rd_addr!(inst.inst);
-        let rd_addr  = get_rd_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
 
         let mut tcg_lists = vec![];
 
         let source1 = self.tcg_temp_new();
 
         tcg_lists.push(TCGOp::tcg_get_gpr(source1, rs1_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, source1, source1, TCGv::new_imm(imm_const as u64)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(imm_const as u64),
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
 
         self.tcg_temp_free(source1);
         tcg_lists
     }
-    pub fn translate_c_jal (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_addiw (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_jal(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_addiw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const = get_nzimm!(inst.inst as i32);
-        let rd_addr = get_rd_addr!(inst.inst); 
+        let rd_addr = get_rd_addr!(inst.inst);
 
         let mut tcg_lists = vec![];
 
         let source1 = self.tcg_temp_new();
 
         tcg_lists.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_32BIT, source1, source1, TCGv::new_imm(imm_const as u64)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_32BIT,
+            source1,
+            source1,
+            TCGv::new_imm(imm_const as u64),
+        ));
         tcg_lists.push(TCGOp::new_2op(TCGOpcode::SIGN_EXT_32_64, source1, source1));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         self.tcg_temp_free(source1);
-        
+
         tcg_lists
     }
 
-
-    pub fn translate_c_li (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_li(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const = get_nzimm!(inst.inst as i32);
-        let rd_addr  = get_rd_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
         let mut tcg_lists = vec![];
 
         let dest_tmp = self.tcg_temp_new();
         tcg_lists.push(TCGOp::tcg_get_gpr(dest_tmp, 0));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, dest_tmp, dest_tmp, TCGv::new_imm(imm_const as u64)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            dest_tmp,
+            dest_tmp,
+            TCGv::new_imm(imm_const as u64),
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, dest_tmp));
 
         self.tcg_temp_free(dest_tmp);
         tcg_lists
     }
 
-
-    pub fn translate_c_addi16sp (&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+    pub fn translate_c_addi16sp(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const = get_nzimm_addi16sp!(inst.inst as i32);
-        let rs1_addr= 2;  // sp
-        let rd_addr = 2;  // sp
+        let rs1_addr = 2; // sp
+        let rd_addr = 2; // sp
 
         let mut tcg_lists = vec![];
 
         let source1 = self.tcg_temp_new();
 
         tcg_lists.push(TCGOp::tcg_get_gpr(source1, rs1_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, source1, source1, TCGv::new_imm(imm_const as u64)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(imm_const as u64),
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
 
         self.tcg_temp_free(source1);
         tcg_lists
     }
 
-    pub fn translate_c_lui   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_lui(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const = get_nzimm_lui!(inst.inst as i32);
-        let rd_addr  = get_rd_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
         let mut tcg_lists = vec![];
 
         let dest_tmp = self.tcg_temp_new();
         tcg_lists.push(TCGOp::tcg_get_gpr(dest_tmp, 0));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, dest_tmp, dest_tmp, TCGv::new_imm(imm_const as u64)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            dest_tmp,
+            dest_tmp,
+            TCGv::new_imm(imm_const as u64),
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, dest_tmp));
 
         self.tcg_temp_free(dest_tmp);
         tcg_lists
     }
 
-    pub fn translate_c_srli  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let shamt    = get_nzimm!(inst.inst);
-        let rd_addr  = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+    pub fn translate_c_srli(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let shamt = get_nzimm!(inst.inst);
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
 
         let mut tcg_list = vec![];
 
         let source1 = self.tcg_temp_new();
         tcg_list.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_list.push(TCGOp::new_3op(TCGOpcode::SRL_64BIT, source1, source1, TCGv::new_imm(shamt as u64)));
+        tcg_list.push(TCGOp::new_3op(
+            TCGOpcode::SRL_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(shamt as u64),
+        ));
         tcg_list.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         self.tcg_temp_free(source1);
 
         tcg_list
     }
 
-
-    pub fn translate_c_srli64 (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let shamt    = get_nzimm!(inst.inst);
-        let rd_addr  = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+    pub fn translate_c_srli64(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let shamt = get_nzimm!(inst.inst);
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
 
         let mut tcg_list = vec![];
 
         let source1 = self.tcg_temp_new();
         tcg_list.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_list.push(TCGOp::new_3op(TCGOpcode::SRL_64BIT, source1, source1, TCGv::new_imm(shamt as u64)));
+        tcg_list.push(TCGOp::new_3op(
+            TCGOpcode::SRL_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(shamt as u64),
+        ));
         tcg_list.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         self.tcg_temp_free(source1);
 
         tcg_list
     }
 
-    pub fn translate_c_srai  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let shamt    = get_nzimm!(inst.inst);
-        let rd_addr  = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+    pub fn translate_c_srai(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let shamt = get_nzimm!(inst.inst);
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
 
         let mut tcg_list = vec![];
 
         let source1 = self.tcg_temp_new();
         tcg_list.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_list.push(TCGOp::new_3op(TCGOpcode::SRA_64BIT, source1, source1, TCGv::new_imm(shamt as u64)));
+        tcg_list.push(TCGOp::new_3op(
+            TCGOpcode::SRA_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(shamt as u64),
+        ));
         tcg_list.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         self.tcg_temp_free(source1);
 
         tcg_list
     }
 
-
-    pub fn translate_c_srai64 (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let shamt    = get_nzimm!(inst.inst);
-        let rd_addr  = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+    pub fn translate_c_srai64(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let shamt = get_nzimm!(inst.inst);
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
 
         let mut tcg_list = vec![];
 
         let source1 = self.tcg_temp_new();
         tcg_list.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_list.push(TCGOp::new_3op(TCGOpcode::SRA_64BIT, source1, source1, TCGv::new_imm(shamt as u64)));
+        tcg_list.push(TCGOp::new_3op(
+            TCGOpcode::SRA_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(shamt as u64),
+        ));
         tcg_list.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         self.tcg_temp_free(source1);
 
         tcg_list
     }
 
-
-    pub fn translate_c_andi  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_andi(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const = get_nzimm!(inst.inst as i32);
-        let rd_addr  = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
 
         let mut tcg_lists = vec![];
 
         let source1 = self.tcg_temp_new();
 
         tcg_lists.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::AND_64BIT, source1, source1, TCGv::new_imm(imm_const as u64)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::AND_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(imm_const as u64),
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
 
         self.tcg_temp_free(source1);
         tcg_lists
     }
 
-
-    pub fn translate_c_sub   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = get_c_reg_addr!((inst.inst >> 7) & 0x7);
-        let rs2_addr  = get_c_reg_addr!((inst.inst >> 2) & 0x7);
+    pub fn translate_c_sub(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rs2_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
 
@@ -299,8 +401,13 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SUB_64BIT, rd_tmp, rd_tmp, rs2_tmp));
+
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SUB_64BIT,
+            rd_tmp,
+            rd_tmp,
+            rs2_tmp,
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
         self.tcg_temp_free(rd_tmp);
@@ -309,10 +416,9 @@ impl TranslateRiscv {
         tcg_lists
     }
 
-
-    pub fn translate_c_xor   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = get_c_reg_addr!((inst.inst >> 7) & 0x7);
-        let rs2_addr  = get_c_reg_addr!((inst.inst >> 2) & 0x7);
+    pub fn translate_c_xor(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rs2_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
 
@@ -321,19 +427,23 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::XOR_64BIT, rd_tmp, rd_tmp, rs2_tmp));
+
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::XOR_64BIT,
+            rd_tmp,
+            rd_tmp,
+            rs2_tmp,
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
         self.tcg_temp_free(rd_tmp);
         self.tcg_temp_free(rs2_tmp);
 
         tcg_lists
-
     }
-    pub fn translate_c_or    (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = get_c_reg_addr!((inst.inst >> 7) & 0x7);
-        let rs2_addr  = get_c_reg_addr!((inst.inst >> 2) & 0x7);
+    pub fn translate_c_or(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rs2_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
 
@@ -342,7 +452,7 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        
+
         tcg_lists.push(TCGOp::new_3op(TCGOpcode::OR_64BIT, rd_tmp, rd_tmp, rs2_tmp));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
@@ -351,9 +461,9 @@ impl TranslateRiscv {
 
         tcg_lists
     }
-    pub fn translate_c_and   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = get_c_reg_addr!((inst.inst >> 7) & 0x7);
-        let rs2_addr  = get_c_reg_addr!((inst.inst >> 2) & 0x7);
+    pub fn translate_c_and(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rs2_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
 
@@ -362,8 +472,13 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::AND_64BIT, rd_tmp, rd_tmp, rs2_tmp));
+
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::AND_64BIT,
+            rd_tmp,
+            rd_tmp,
+            rs2_tmp,
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
         self.tcg_temp_free(rd_tmp);
@@ -372,10 +487,9 @@ impl TranslateRiscv {
         tcg_lists
     }
 
-
-    pub fn translate_c_subw  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = get_c_reg_addr!((inst.inst >> 7) & 0x7);
-        let rs2_addr  = get_c_reg_addr!((inst.inst >> 2) & 0x7);
+    pub fn translate_c_subw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rs2_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
 
@@ -384,20 +498,24 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SUB_32BIT, rd_tmp, rd_tmp, rs2_tmp));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SUB_32BIT,
+            rd_tmp,
+            rd_tmp,
+            rs2_tmp,
+        ));
         tcg_lists.push(TCGOp::new_2op(TCGOpcode::SIGN_EXT_32_64, rd_tmp, rd_tmp));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
         self.tcg_temp_free(rd_tmp);
         self.tcg_temp_free(rs2_tmp);
-        
+
         tcg_lists
     }
 
-
-    pub fn translate_c_addw  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = get_c_reg_addr!((inst.inst >> 7) & 0x7);
-        let rs2_addr  = get_c_reg_addr!((inst.inst >> 2) & 0x7);
+    pub fn translate_c_addw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = get_c_reg_addr!((inst.inst >> 7) & 0x7);
+        let rs2_addr = get_c_reg_addr!((inst.inst >> 2) & 0x7);
 
         let mut tcg_lists = vec![];
 
@@ -406,44 +524,53 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_32BIT, rd_tmp, rd_tmp, rs2_tmp));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_32BIT,
+            rd_tmp,
+            rd_tmp,
+            rs2_tmp,
+        ));
         tcg_lists.push(TCGOp::new_2op(TCGOpcode::SIGN_EXT_32_64, rd_tmp, rd_tmp));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
         self.tcg_temp_free(rd_tmp);
         self.tcg_temp_free(rs2_tmp);
-        
+
         tcg_lists
     }
-    pub fn translate_c_j (&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        let jmp_const = (((inst.inst >> 12) & 0x1) << 11) |
-                        (((inst.inst >> 11) & 0x1) <<  4) |
-                        (((inst.inst >>  9) & 0x3) <<  8) |
-                        (((inst.inst >>  8) & 0x1) << 10) |
-                        (((inst.inst >>  7) & 0x1) <<  6) |
-                        (((inst.inst >>  6) & 0x1) <<  7) |
-                        (((inst.inst >>  3) & 0x7) <<  1) |
-                        (((inst.inst >>  2) & 0x1) <<  5);
+    pub fn translate_c_j(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let jmp_const = (((inst.inst >> 12) & 0x1) << 11)
+            | (((inst.inst >> 11) & 0x1) << 4)
+            | (((inst.inst >> 9) & 0x3) << 8)
+            | (((inst.inst >> 8) & 0x1) << 10)
+            | (((inst.inst >> 7) & 0x1) << 6)
+            | (((inst.inst >> 6) & 0x1) << 7)
+            | (((inst.inst >> 3) & 0x7) << 1)
+            | (((inst.inst >> 2) & 0x1) << 5);
         let jmp_const = extend_sign(jmp_const as u64, 11);
 
         let mut tcg_lists = vec![];
 
         let dest_temp = self.tcg_temp_new();
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::JMPIM, dest_temp, TCGv::new_imm(inst.addr.wrapping_add(jmp_const as u64))));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::JMPIM,
+            dest_temp,
+            TCGv::new_imm(inst.addr.wrapping_add(jmp_const as u64)),
+        ));
         tcg_lists.push(TCGOp::new_0op(TCGOpcode::EXIT_TB, None));
         self.tcg_temp_free(dest_temp);
 
         tcg_lists
     }
-    pub fn translate_c_beqz  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_beqz(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1_addr: usize = get_c_reg_addr!((inst.inst >> 7) & 0x7) as usize;
 
-        let target = (((inst.inst >> 12) & 0x1) << 8) |
-                     (((inst.inst >> 10) & 0x3) << 3) |
-                     (((inst.inst >>  5) & 0x3) << 6) |
-                     (((inst.inst >>  3) & 0x3) << 1) |
-                     (((inst.inst >>  2) & 0x1) << 5);
-        let target = extend_sign (target as u64, 8);
+        let target = (((inst.inst >> 12) & 0x1) << 8)
+            | (((inst.inst >> 10) & 0x3) << 3)
+            | (((inst.inst >> 5) & 0x3) << 6)
+            | (((inst.inst >> 3) & 0x3) << 1)
+            | (((inst.inst >> 2) & 0x1) << 5);
+        let target = extend_sign(target as u64, 8);
         let target = inst.addr.wrapping_add(target as u64);
         let label = Rc::new(RefCell::new(TCGLabel::new()));
 
@@ -455,24 +582,30 @@ impl TranslateRiscv {
         tcg_lists.push(TCGOp::tcg_get_gpr(rs1, rs1_addr as u32));
         tcg_lists.push(TCGOp::tcg_get_gpr(zero, 0 as u32));
 
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::EQ_64BIT, rs1, zero, TCGv::new_imm(target as u64), Rc::clone(&label)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::EQ_64BIT,
+            rs1,
+            zero,
+            TCGv::new_imm(target as u64),
+            Rc::clone(&label),
+        ));
         tcg_lists.push(TCGOp::new_goto_tb(TCGv::new_imm(inst.addr + 2)));
         tcg_lists.push(TCGOp::new_label(Rc::clone(&label)));
-        tcg_lists.push(TCGOp::new_goto_tb(TCGv::new_imm(target  as u64)));
+        tcg_lists.push(TCGOp::new_goto_tb(TCGv::new_imm(target as u64)));
 
         self.tcg_temp_free(rs1);
         self.tcg_temp_free(zero);
 
         tcg_lists
     }
-    pub fn translate_c_bnez  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_c_bnez(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1_addr: usize = get_c_reg_addr!((inst.inst >> 7) & 0x7) as usize;
-        let target = (((inst.inst >> 12) & 0x1) << 8) |
-                     (((inst.inst >> 10) & 0x3) << 3) |
-                     (((inst.inst >>  5) & 0x3) << 6) |
-                     (((inst.inst >>  3) & 0x3) << 1) |
-                     (((inst.inst >>  2) & 0x1) << 5);
-        let target = extend_sign (target as u64, 8);
+        let target = (((inst.inst >> 12) & 0x1) << 8)
+            | (((inst.inst >> 10) & 0x3) << 3)
+            | (((inst.inst >> 5) & 0x3) << 6)
+            | (((inst.inst >> 3) & 0x3) << 1)
+            | (((inst.inst >> 2) & 0x1) << 5);
+        let target = extend_sign(target as u64, 8);
         let target = inst.addr.wrapping_add(target as u64);
         let label = Rc::new(RefCell::new(TCGLabel::new()));
 
@@ -484,10 +617,16 @@ impl TranslateRiscv {
         tcg_lists.push(TCGOp::tcg_get_gpr(rs1, rs1_addr as u32));
         tcg_lists.push(TCGOp::tcg_get_gpr(zero, 0 as u32));
 
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::NE_64BIT, rs1, zero, TCGv::new_imm(target as u64), Rc::clone(&label)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::NE_64BIT,
+            rs1,
+            zero,
+            TCGv::new_imm(target as u64),
+            Rc::clone(&label),
+        ));
         tcg_lists.push(TCGOp::new_goto_tb(TCGv::new_imm(inst.addr + 2)));
         tcg_lists.push(TCGOp::new_label(Rc::clone(&label)));
-        tcg_lists.push(TCGOp::new_goto_tb(TCGv::new_imm(target  as u64)));
+        tcg_lists.push(TCGOp::new_goto_tb(TCGv::new_imm(target as u64)));
 
         self.tcg_temp_free(rs1);
         self.tcg_temp_free(zero);
@@ -495,45 +634,61 @@ impl TranslateRiscv {
         tcg_lists
     }
 
-
-    pub fn translate_c_slli  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let shamt    = get_nzimm!(inst.inst);
-        let rd_addr  = get_rd_addr!(inst.inst);
+    pub fn translate_c_slli(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let shamt = get_nzimm!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
 
         let mut tcg_list = vec![];
 
         let source1 = self.tcg_temp_new();
         tcg_list.push(TCGOp::tcg_get_gpr(source1, rd_addr));
-        tcg_list.push(TCGOp::new_3op(TCGOpcode::SLL_64BIT, source1, source1, TCGv::new_imm(shamt as u64)));
+        tcg_list.push(TCGOp::new_3op(
+            TCGOpcode::SLL_64BIT,
+            source1,
+            source1,
+            TCGv::new_imm(shamt as u64),
+        ));
         tcg_list.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         self.tcg_temp_free(source1);
 
         tcg_list
     }
-    pub fn translate_c_fldsp (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_lwsp  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = (((inst.inst >> 12) & 0x1) << 5) |
-                      (((inst.inst >>  4) & 0x7) << 2) |
-                      (((inst.inst >>  2) & 0x3) << 6);
-
-        self.translate_raw_load(2, 
-                                imm as u64, 
-                                get_rd_addr!(inst.inst),
-                                inst, TCGOpcode::LOAD_32BIT, CALL_HELPER_IDX::CALL_LOAD32_IDX)
+    pub fn translate_c_fldsp(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
     }
-    pub fn translate_c_flwsp (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_ldsp  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = (((inst.inst >> 12) & 0x1) << 5) |
-                      (((inst.inst >>  4) & 0x7) << 2) |
-                      (((inst.inst >>  2) & 0x3) << 6);
+    pub fn translate_c_lwsp(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = (((inst.inst >> 12) & 0x1) << 5)
+            | (((inst.inst >> 4) & 0x7) << 2)
+            | (((inst.inst >> 2) & 0x3) << 6);
 
-        self.translate_raw_load(2,
-                                imm as u64, 
-                                get_rd_addr!(inst.inst),
-                                inst, TCGOpcode::LOAD_64BIT, CALL_HELPER_IDX::CALL_LOAD64_IDX)
+        self.translate_raw_load(
+            2,
+            imm as u64,
+            get_rd_addr!(inst.inst),
+            inst,
+            TCGOpcode::LOAD_32BIT,
+            CALL_HELPER_IDX::CALL_LOAD32_IDX,
+        )
     }
-    pub fn translate_c_jr    (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rs1_addr = get_rd_addr!(inst.inst);   // src1 is 11-7 bitfield
+    pub fn translate_c_flwsp(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_ldsp(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = (((inst.inst >> 12) & 0x1) << 5)
+            | (((inst.inst >> 4) & 0x7) << 2)
+            | (((inst.inst >> 2) & 0x3) << 6);
+
+        self.translate_raw_load(
+            2,
+            imm as u64,
+            get_rd_addr!(inst.inst),
+            inst,
+            TCGOpcode::LOAD_64BIT,
+            CALL_HELPER_IDX::CALL_LOAD64_IDX,
+        )
+    }
+    pub fn translate_c_jr(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rs1_addr = get_rd_addr!(inst.inst); // src1 is 11-7 bitfield
 
         let mut tcg_lists = vec![];
 
@@ -542,7 +697,12 @@ impl TranslateRiscv {
         tcg_lists.push(TCGOp::tcg_get_gpr(source1, rs1_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(dest, 0));
 
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::JMPR, dest, source1, TCGv::new_imm(0)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::JMPR,
+            dest,
+            source1,
+            TCGv::new_imm(0),
+        ));
         tcg_lists.push(TCGOp::new_0op(TCGOpcode::EXIT_TB, None));
 
         self.tcg_temp_free(source1);
@@ -550,9 +710,9 @@ impl TranslateRiscv {
 
         tcg_lists
     }
-    pub fn translate_c_mv    (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = (inst.inst >> 7) & 0x1f;
-        let rs2_addr  = (inst.inst >> 2) & 0x1f;
+    pub fn translate_c_mv(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = (inst.inst >> 7) & 0x1f;
+        let rs2_addr = (inst.inst >> 2) & 0x1f;
 
         let mut tcg_lists = vec![];
 
@@ -561,19 +721,25 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(zero_tmp, 0));
         tcg_lists.push(TCGOp::tcg_get_gpr(val_tmp, rs2_addr));
-        
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, val_tmp, val_tmp, zero_tmp));
+
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            val_tmp,
+            val_tmp,
+            zero_tmp,
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, val_tmp));
 
         self.tcg_temp_free(val_tmp);
         self.tcg_temp_free(zero_tmp);
 
         tcg_lists
-
     }
-    pub fn translate_c_ebreak (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_jalr  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rs1_addr = get_rd_addr!(inst.inst);   // src1 is 11-7 bitfield
+    pub fn translate_c_ebreak(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_jalr(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rs1_addr = get_rd_addr!(inst.inst); // src1 is 11-7 bitfield
 
         let mut tcg_lists = vec![];
 
@@ -588,7 +754,12 @@ impl TranslateRiscv {
         self.tcg_temp_free(zero);
         tcg_lists.push(TCGOp::tcg_set_gpr(1, dest));
 
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::JMPR, dest, source1, TCGv::new_imm(0)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::JMPR,
+            dest,
+            source1,
+            TCGv::new_imm(0),
+        ));
         tcg_lists.push(TCGOp::new_0op(TCGOpcode::EXIT_TB, None));
 
         self.tcg_temp_free(source1);
@@ -597,9 +768,9 @@ impl TranslateRiscv {
         tcg_lists
     }
 
-    pub fn translate_c_add   (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let rd_addr   = (inst.inst >> 7) & 0x1f;
-        let rs2_addr  = (inst.inst >> 2) & 0x1f;
+    pub fn translate_c_add(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let rd_addr = (inst.inst >> 7) & 0x1f;
+        let rs2_addr = (inst.inst >> 2) & 0x1f;
 
         let mut tcg_lists = vec![];
 
@@ -608,8 +779,13 @@ impl TranslateRiscv {
 
         tcg_lists.push(TCGOp::tcg_get_gpr(rd_tmp, rd_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_tmp, rs2_addr));
-        
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, rd_tmp, rd_tmp, rs2_tmp));
+
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            rd_tmp,
+            rd_tmp,
+            rs2_tmp,
+        ));
         tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, rd_tmp));
 
         self.tcg_temp_free(rd_tmp);
@@ -617,26 +793,34 @@ impl TranslateRiscv {
 
         tcg_lists
     }
-    pub fn translate_c_fsdsp (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_swsp  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = (((inst.inst >> 9) & 0xf) << 2) |
-                      (((inst.inst >> 7) & 0x3) << 6);
-
-        self.translate_raw_store(2,
-                          imm as u64, 
-                          (inst.inst >> 2) & 0x1f, 
-                                 inst, TCGOpcode::STORE_32BIT, CALL_HELPER_IDX::CALL_STORE32_IDX)
+    pub fn translate_c_fsdsp(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
     }
-    pub fn translate_c_fswsp (&mut self, _inst: &InstrInfo) -> Vec<TCGOp> { vec![] }
-    pub fn translate_c_sdsp  (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
-        let imm = (((inst.inst >> 9) & 0xf) << 2) |
-                      (((inst.inst >> 7) & 0x3) << 6);
+    pub fn translate_c_swsp(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = (((inst.inst >> 9) & 0xf) << 2) | (((inst.inst >> 7) & 0x3) << 6);
 
-        self.translate_raw_store(2,
-                          imm as u64, 
-                          (inst.inst >> 2) & 0x1f, 
-                          inst, TCGOpcode::STORE_64BIT, CALL_HELPER_IDX::CALL_STORE64_IDX)
+        self.translate_raw_store(
+            2,
+            imm as u64,
+            (inst.inst >> 2) & 0x1f,
+            inst,
+            TCGOpcode::STORE_32BIT,
+            CALL_HELPER_IDX::CALL_STORE32_IDX,
+        )
     }
+    pub fn translate_c_fswsp(&mut self, _inst: &InstrInfo) -> Vec<TCGOp> {
+        vec![]
+    }
+    pub fn translate_c_sdsp(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
+        let imm = (((inst.inst >> 9) & 0xf) << 2) | (((inst.inst >> 7) & 0x3) << 6);
 
-
+        self.translate_raw_store(
+            2,
+            imm as u64,
+            (inst.inst >> 2) & 0x1f,
+            inst,
+            TCGOpcode::STORE_64BIT,
+            CALL_HELPER_IDX::CALL_STORE64_IDX,
+        )
+    }
 }

--- a/src/target/riscv/translate_riscv_fp.rs
+++ b/src/target/riscv/translate_riscv_fp.rs
@@ -1,21 +1,20 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::super::super::tcg::tcg::{TCGOp, TCGOpcode, TCGv, TCGLabel};
 use super::super::super::instr_info::InstrInfo;
-use super::riscv::{CALL_HELPER_IDX, CallFcvtIdx};
+use super::super::super::tcg::tcg::{TCGLabel, TCGOp, TCGOpcode, TCGv};
+use super::riscv::{CallFcvtIdx, CALL_HELPER_IDX};
 
+use super::super::super::get_rd_addr;
 use super::super::super::get_rs1_addr;
 use super::super::super::get_rs2_addr;
 use super::super::super::get_rs3_addr;
-use super::super::super::get_rd_addr;
 
 use super::riscv::TranslateRiscv;
 
 impl TranslateRiscv {
     pub fn translate_fld(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
-        
 
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let imm = Box::new(TCGv::new_imm(imm_const));
@@ -25,12 +24,24 @@ impl TranslateRiscv {
 
         let label = Rc::new(RefCell::new(TCGLabel::new()));
 
-        let tcg_call_op = TCGOp::new_helper_call_arg4(CALL_HELPER_IDX::CALL_FLOAT_LOAD64_IDX as usize, *rd, *rs1, *imm, *tcg_inst_addr);
+        let tcg_call_op = TCGOp::new_helper_call_arg4(
+            CALL_HELPER_IDX::CALL_FLOAT_LOAD64_IDX as usize,
+            *rd,
+            *rs1,
+            *imm,
+            *tcg_inst_addr,
+        );
 
-        let zero = Box::new(TCGv::new_reg(0 as u64));        
+        let zero = Box::new(TCGv::new_reg(0 as u64));
         let dummy_addr = Box::new(TCGv::new_imm(0));
 
-        let result_cmp_op = TCGOp::new_4op(TCGOpcode::EQ_EAX_64BIT, *rs1, *zero, *dummy_addr, Rc::clone(&label));
+        let result_cmp_op = TCGOp::new_4op(
+            TCGOpcode::EQ_EAX_64BIT,
+            *rs1,
+            *zero,
+            *dummy_addr,
+            Rc::clone(&label),
+        );
         let exit_tb = TCGOp::new_0op(TCGOpcode::EXIT_TB, None);
         let tcg_set_label = TCGOp::new_label(Rc::clone(&label));
 
@@ -40,7 +51,6 @@ impl TranslateRiscv {
     }
     pub fn translate_flw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
-        
 
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let imm = Box::new(TCGv::new_imm(imm_const));
@@ -50,12 +60,24 @@ impl TranslateRiscv {
 
         let label = Rc::new(RefCell::new(TCGLabel::new()));
 
-        let tcg_call_op = TCGOp::new_helper_call_arg4(CALL_HELPER_IDX::CALL_FLOAT_LOAD32_IDX as usize, *rd, *rs1, *imm, *tcg_inst_addr);
+        let tcg_call_op = TCGOp::new_helper_call_arg4(
+            CALL_HELPER_IDX::CALL_FLOAT_LOAD32_IDX as usize,
+            *rd,
+            *rs1,
+            *imm,
+            *tcg_inst_addr,
+        );
 
-        let zero = Box::new(TCGv::new_reg(0 as u64));        
+        let zero = Box::new(TCGv::new_reg(0 as u64));
         let dummy_addr = Box::new(TCGv::new_imm(0));
 
-        let result_cmp_op = TCGOp::new_4op(TCGOpcode::EQ_EAX_64BIT, *rs1, *zero, *dummy_addr, Rc::clone(&label));
+        let result_cmp_op = TCGOp::new_4op(
+            TCGOpcode::EQ_EAX_64BIT,
+            *rs1,
+            *zero,
+            *dummy_addr,
+            Rc::clone(&label),
+        );
         let exit_tb = TCGOp::new_0op(TCGOpcode::EXIT_TB, None);
         let tcg_set_label = TCGOp::new_label(Rc::clone(&label));
 
@@ -65,7 +87,6 @@ impl TranslateRiscv {
     }
     pub fn translate_fsd(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
-        
 
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let imm = Box::new(TCGv::new_imm(imm_const));
@@ -75,12 +96,24 @@ impl TranslateRiscv {
 
         let label = Rc::new(RefCell::new(TCGLabel::new()));
 
-        let tcg_call_op = TCGOp::new_helper_call_arg4(CALL_HELPER_IDX::CALL_FLOAT_STORE64_IDX as usize, *rd, *rs1, *imm, *tcg_inst_addr);
+        let tcg_call_op = TCGOp::new_helper_call_arg4(
+            CALL_HELPER_IDX::CALL_FLOAT_STORE64_IDX as usize,
+            *rd,
+            *rs1,
+            *imm,
+            *tcg_inst_addr,
+        );
 
-        let zero = Box::new(TCGv::new_reg(0 as u64));        
+        let zero = Box::new(TCGv::new_reg(0 as u64));
         let dummy_addr = Box::new(TCGv::new_imm(0));
 
-        let result_cmp_op = TCGOp::new_4op(TCGOpcode::EQ_EAX_64BIT, *rs1, *zero, *dummy_addr, Rc::clone(&label));
+        let result_cmp_op = TCGOp::new_4op(
+            TCGOpcode::EQ_EAX_64BIT,
+            *rs1,
+            *zero,
+            *dummy_addr,
+            Rc::clone(&label),
+        );
         let exit_tb = TCGOp::new_0op(TCGOpcode::EXIT_TB, None);
         let tcg_set_label = TCGOp::new_label(Rc::clone(&label));
 
@@ -90,7 +123,6 @@ impl TranslateRiscv {
     }
     pub fn translate_fsw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
-        
 
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let imm = Box::new(TCGv::new_imm(imm_const));
@@ -100,12 +132,24 @@ impl TranslateRiscv {
 
         let label = Rc::new(RefCell::new(TCGLabel::new()));
 
-        let tcg_call_op = TCGOp::new_helper_call_arg4(CALL_HELPER_IDX::CALL_FLOAT_STORE32_IDX as usize, *rd, *rs1, *imm, *tcg_inst_addr);
+        let tcg_call_op = TCGOp::new_helper_call_arg4(
+            CALL_HELPER_IDX::CALL_FLOAT_STORE32_IDX as usize,
+            *rd,
+            *rs1,
+            *imm,
+            *tcg_inst_addr,
+        );
 
-        let zero = Box::new(TCGv::new_reg(0 as u64));        
+        let zero = Box::new(TCGv::new_reg(0 as u64));
         let dummy_addr = Box::new(TCGv::new_imm(0));
 
-        let result_cmp_op = TCGOp::new_4op(TCGOpcode::EQ_EAX_64BIT, *rs1, *zero, *dummy_addr, Rc::clone(&label));
+        let result_cmp_op = TCGOp::new_4op(
+            TCGOpcode::EQ_EAX_64BIT,
+            *rs1,
+            *zero,
+            *dummy_addr,
+            Rc::clone(&label),
+        );
         let exit_tb = TCGOp::new_0op(TCGOpcode::EXIT_TB, None);
         let tcg_set_label = TCGOp::new_label(Rc::clone(&label));
 
@@ -116,7 +160,7 @@ impl TranslateRiscv {
 
     pub fn translate_fadd_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fadd_d =
@@ -126,7 +170,7 @@ impl TranslateRiscv {
 
     pub fn translate_fsub_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fsub_d =
@@ -136,7 +180,7 @@ impl TranslateRiscv {
 
     pub fn translate_fmul_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fmul_d =
@@ -146,47 +190,71 @@ impl TranslateRiscv {
 
     pub fn translate_fmadd_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FMADD_D_IDX as usize, *rd, *rs1, *rs2, *rs3);        vec![fop]
+            CALL_HELPER_IDX::CALL_FMADD_D_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
+        vec![fop]
     }
 
     pub fn translate_fmsub_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FMSUB_D_IDX as usize, *rd, *rs1, *rs2, *rs3);        vec![fop]
+            CALL_HELPER_IDX::CALL_FMSUB_D_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
+        vec![fop]
     }
 
     pub fn translate_fnmsub_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FNMSUB_D_IDX as usize, *rd, *rs1, *rs2, *rs3);        vec![fop]
+            CALL_HELPER_IDX::CALL_FNMSUB_D_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
+        vec![fop]
     }
 
     pub fn translate_fnmadd_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FNMADD_D_IDX as usize, *rd, *rs1, *rs2, *rs3);        vec![fop]
+            CALL_HELPER_IDX::CALL_FNMADD_D_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
+        vec![fop]
     }
 
     pub fn translate_fdiv_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fdiv_d =
@@ -211,7 +279,6 @@ impl TranslateRiscv {
         vec![mov_x_d]
     }
 
-
     pub fn translate_fmv_d_x(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
@@ -222,26 +289,29 @@ impl TranslateRiscv {
 
     pub fn translate_feq_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FEQ_D_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FEQ_D_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
     pub fn translate_flt_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLT_D_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLT_D_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
     pub fn translate_fle_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLE_D_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLE_D_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
 
@@ -249,31 +319,34 @@ impl TranslateRiscv {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg2(CALL_HELPER_IDX::CALL_FCLASS_D_IDX as usize, *rd, *rs1);
+        let op =
+            TCGOp::new_helper_call_arg2(CALL_HELPER_IDX::CALL_FCLASS_D_IDX as usize, *rd, *rs1);
         vec![op]
     }
 
     pub fn translate_fmax_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMAX_D_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMAX_D_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
 
     pub fn translate_fmin_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMIN_D_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMIN_D_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
 
     pub fn translate_fsgnj_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let op = TCGOp::new_3op(TCGOpcode::SGNJ_64BIT, *rd, *rs1, *rs2);
@@ -282,7 +355,7 @@ impl TranslateRiscv {
 
     pub fn translate_fsgnjn_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let op = TCGOp::new_3op(TCGOpcode::SGNJN_64BIT, *rd, *rs1, *rs2);
@@ -291,7 +364,7 @@ impl TranslateRiscv {
 
     pub fn translate_fsgnjx_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let op = TCGOp::new_3op(TCGOpcode::SGNJX_64BIT, *rd, *rs1, *rs2);
@@ -300,7 +373,7 @@ impl TranslateRiscv {
 
     pub fn translate_fadd_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fadd_s =
@@ -310,7 +383,7 @@ impl TranslateRiscv {
 
     pub fn translate_fsub_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fsub_s =
@@ -320,7 +393,7 @@ impl TranslateRiscv {
 
     pub fn translate_fmul_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fmul_s =
@@ -330,51 +403,71 @@ impl TranslateRiscv {
 
     pub fn translate_fmadd_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FMADD_S_IDX as usize, *rd, *rs1, *rs2, *rs3);        
+            CALL_HELPER_IDX::CALL_FMADD_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
         vec![fop]
     }
 
     pub fn translate_fmsub_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FMSUB_S_IDX as usize, *rd, *rs1, *rs2, *rs3);       
+            CALL_HELPER_IDX::CALL_FMSUB_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
         vec![fop]
     }
 
     pub fn translate_fnmsub_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FNMSUB_S_IDX as usize, *rd, *rs1, *rs2, *rs3);
+            CALL_HELPER_IDX::CALL_FNMSUB_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
         vec![fop]
     }
 
     pub fn translate_fnmadd_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rs3 = Box::new(TCGv::new_reg(get_rs3_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fop = TCGOp::new_helper_call_arg4(
-            CALL_HELPER_IDX::CALL_FNMADD_S_IDX as usize, *rd, *rs1, *rs2, *rs3);
+            CALL_HELPER_IDX::CALL_FNMADD_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+            *rs3,
+        );
         vec![fop]
     }
 
     pub fn translate_fdiv_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
         let fdiv_s =
@@ -399,7 +492,6 @@ impl TranslateRiscv {
         vec![mov_x_s]
     }
 
-
     pub fn translate_fmv_s_x(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
@@ -410,26 +502,29 @@ impl TranslateRiscv {
 
     pub fn translate_feq_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FEQ_S_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FEQ_S_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
     pub fn translate_flt_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLT_S_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLT_S_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
     pub fn translate_fle_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLE_S_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FLE_S_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
 
@@ -437,7 +532,8 @@ impl TranslateRiscv {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg2(CALL_HELPER_IDX::CALL_FCLASS_S_IDX as usize, *rd, *rs1);
+        let op =
+            TCGOp::new_helper_call_arg2(CALL_HELPER_IDX::CALL_FCLASS_S_IDX as usize, *rd, *rs1);
         vec![op]
     }
 
@@ -449,7 +545,6 @@ impl TranslateRiscv {
         vec![mov_x_d]
     }
 
-
     pub fn translate_fmv_w_x(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
@@ -460,211 +555,315 @@ impl TranslateRiscv {
 
     pub fn translate_fmax_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMAX_S_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMAX_S_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
 
     pub fn translate_fmin_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMIN_S_IDX as usize, *rd, *rs1, *rs2);
+        let op =
+            TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FMIN_S_IDX as usize, *rd, *rs1, *rs2);
         vec![op]
     }
 
     pub fn translate_fsgnj_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FSGNJ_S_IDX as usize, *rd, *rs1, *rs2);
+        let op = TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FSGNJ_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+        );
         vec![op]
     }
 
     pub fn translate_fsgnjn_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FSGNJN_S_IDX as usize, *rd, *rs1, *rs2);
+        let op = TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FSGNJN_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+        );
         vec![op]
     }
 
     pub fn translate_fsgnjx_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1 = Box::new(TCGv::new_reg(get_rs1_addr!(inst.inst) as u64));
-        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst)as u64));
+        let rs2 = Box::new(TCGv::new_reg(get_rs2_addr!(inst.inst) as u64));
         let rd = Box::new(TCGv::new_reg(get_rd_addr!(inst.inst) as u64));
 
-        let op = TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FSGNJX_S_IDX as usize, *rd, *rs1, *rs2);
+        let op = TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FSGNJX_S_IDX as usize,
+            *rd,
+            *rs1,
+            *rs2,
+        );
         vec![op]
     }
 
-    pub fn translate_fcvt_w_s (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_w_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::W_S as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx, rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_wu_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_wu_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::WU_S as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_s_w (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_s_w(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::S_W as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_s_wu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_s_wu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::S_WU as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_s_d (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_s_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::S_D as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_d_s (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_d_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::D_S as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_w_d (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_w_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::W_D as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_wu_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_wu_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::WU_D as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_d_w (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_d_w(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::D_W as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_d_wu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_d_wu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::D_WU as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_l_s (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_l_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::L_S as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_lu_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_lu_s(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::LU_S as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_s_l (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_s_l(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::S_L as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_s_lu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_s_lu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::S_LU as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_l_d (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_l_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::L_D as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_lu_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_lu_d(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::LU_D as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_d_l (&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_d_l(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::D_L as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
 
-    pub fn translate_fcvt_d_lu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> { 
+    pub fn translate_fcvt_d_lu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let mut tcg_lists = vec![];
         let rs1 = TCGv::new_reg(get_rs1_addr!(inst.inst) as u64);
-        let rd  = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
+        let rd = TCGv::new_reg(get_rd_addr!(inst.inst) as u64);
         let fcvt_helper_idx = TCGv::new_imm(CallFcvtIdx::D_LU as u64);
-        tcg_lists.push(TCGOp::new_helper_call_arg3(CALL_HELPER_IDX::CALL_FCVT_IDX as usize, fcvt_helper_idx,  rd, rs1));
-        tcg_lists 
+        tcg_lists.push(TCGOp::new_helper_call_arg3(
+            CALL_HELPER_IDX::CALL_FCVT_IDX as usize,
+            fcvt_helper_idx,
+            rd,
+            rs1,
+        ));
+        tcg_lists
     }
-
-
-
 }

--- a/src/target/riscv/translate_riscv_int.rs
+++ b/src/target/riscv/translate_riscv_int.rs
@@ -1,12 +1,12 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
-use super::super::super::tcg::tcg::{TCGOp, TCGOpcode, TCGv, TCGLabel};
 use super::super::super::instr_info::InstrInfo;
+use super::super::super::tcg::tcg::{TCGLabel, TCGOp, TCGOpcode, TCGv};
 
-use super::super::super::get_rs1_addr;
-use super::super::super::get_rd_addr;
 use super::super::super::extract_j_field;
+use super::super::super::get_rd_addr;
+use super::super::super::get_rs1_addr;
 
 use super::riscv::{TranslateRiscv, CALL_HELPER_IDX};
 
@@ -33,11 +33,10 @@ impl TranslateRiscv {
         tcg_lists
     }
 
-
     pub fn translate_jalr(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         let rs1_addr = get_rs1_addr!(inst.inst);
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
-        let rd_addr  = get_rd_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
 
         let mut tcg_lists = vec![];
 
@@ -64,9 +63,8 @@ impl TranslateRiscv {
         tcg_lists
     }
 
-
     pub fn translate_lui(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rd_addr = get_rd_addr!(inst.inst); 
+        let rd_addr = get_rd_addr!(inst.inst);
 
         let imm_const: u64 = ((inst.inst as i32 as i64) & !0xfff) as u64;
         let tcg_imm = TCGv::new_imm(imm_const);
@@ -76,15 +74,16 @@ impl TranslateRiscv {
         }
 
         let source1 = self.tcg_temp_new();
-        let rs1_op = TCGOp::tcg_get_gpr(source1, 0);  // Box::new(TCGv::new_reg(rs1_addr as u64));
+        let rs1_op = TCGOp::tcg_get_gpr(source1, 0); // Box::new(TCGv::new_reg(rs1_addr as u64));
         let tcg_inst = TCGOp::new_3op(TCGOpcode::ADD_64BIT, source1, source1, tcg_imm);
-        let rd_op = TCGOp::tcg_set_gpr(rd_addr, source1);  // Box::new(TCGv::new_reg(rs1_addr as u64));
+        let rd_op = TCGOp::tcg_set_gpr(rd_addr, source1); // Box::new(TCGv::new_reg(rs1_addr as u64));
         self.tcg_temp_free(source1);
         vec![rs1_op, tcg_inst, rd_op]
     }
 
     pub fn translate_auipc(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        let imm_const = (((inst.inst as i32 as i64) & !0xfff) as u64).wrapping_add(inst.addr as u64);
+        let imm_const =
+            (((inst.inst as i32 as i64) & !0xfff) as u64).wrapping_add(inst.addr as u64);
         let rd_addr = get_rd_addr!(inst.inst);
 
         let imm = TCGv::new_imm(imm_const as u64);
@@ -131,8 +130,8 @@ impl TranslateRiscv {
     }
 
     pub fn translate_addiw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
-        let rd_addr = get_rd_addr!(inst.inst); 
+        let rs1_addr = get_rs1_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
 
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
         let tcg_imm = TCGv::new_imm(imm_const);
@@ -142,10 +141,10 @@ impl TranslateRiscv {
         }
 
         let source1 = self.tcg_temp_new();
-        let rs1_op = TCGOp::tcg_get_gpr(source1, rs1_addr);  // Box::new(TCGv::new_reg(rs1_addr as u64));
+        let rs1_op = TCGOp::tcg_get_gpr(source1, rs1_addr); // Box::new(TCGv::new_reg(rs1_addr as u64));
         let tcg_inst = TCGOp::new_3op(TCGOpcode::ADD_32BIT, source1, source1, tcg_imm);
         let tcg_sign_ext = TCGOp::new_2op(TCGOpcode::SIGN_EXT_32_64, source1, source1);
-        let rd_op = TCGOp::tcg_set_gpr(rd_addr, source1);  // Box::new(TCGv::new_reg(rs1_addr as u64));
+        let rd_op = TCGOp::tcg_set_gpr(rd_addr, source1); // Box::new(TCGv::new_reg(rs1_addr as u64));
         self.tcg_temp_free(source1);
         vec![rs1_op, tcg_inst, tcg_sign_ext, rd_op]
     }
@@ -175,12 +174,20 @@ impl TranslateRiscv {
         self.translate_branch(TCGOpcode::GEU_64BIT, inst)
     }
 
-    pub fn translate_raw_load(&mut self, base_reg: u32, offset: u64, dest_reg: u32, inst: &InstrInfo, load_op: TCGOpcode, helper_op: CALL_HELPER_IDX) -> Vec<TCGOp> {
-        let src_addr       = self.tcg_temp_new();
+    pub fn translate_raw_load(
+        &mut self,
+        base_reg: u32,
+        offset: u64,
+        dest_reg: u32,
+        inst: &InstrInfo,
+        load_op: TCGOpcode,
+        helper_op: CALL_HELPER_IDX,
+    ) -> Vec<TCGOp> {
+        let src_addr = self.tcg_temp_new();
         let vaddr_low12bit = self.tcg_temp_new();
-        let vaddr_tlb_idx  = self.tcg_temp_new();
-        let stack_reg      = self.tcg_temp_new();
-        let tlb_byte_addr  = self.tcg_temp_new();
+        let vaddr_tlb_idx = self.tcg_temp_new();
+        let stack_reg = self.tcg_temp_new();
+        let tlb_byte_addr = self.tcg_temp_new();
 
         let label_tlb_match = Rc::new(RefCell::new(TCGLabel::new()));
         let tcg_label_tlb_match = TCGOp::new_label(Rc::clone(&label_tlb_match));
@@ -191,61 +198,149 @@ impl TranslateRiscv {
         tcg_lists.push(TCGOp::tcg_get_gpr(src_addr, base_reg));
         // Extract TLB Index and offset
         if offset != 0 {
-            tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, src_addr, src_addr, TCGv::new_imm(offset as u64)));
+            tcg_lists.push(TCGOp::new_3op(
+                TCGOpcode::ADD_64BIT,
+                src_addr,
+                src_addr,
+                TCGv::new_imm(offset as u64),
+            ));
         }
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::AND_64BIT, vaddr_low12bit, src_addr, TCGv::new_imm(0xfff)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::AND_64BIT,
+            vaddr_low12bit,
+            src_addr,
+            TCGv::new_imm(0xfff),
+        ));
 
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SRL_64BIT, vaddr_tlb_idx, src_addr, TCGv::new_imm(12)));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::AND_64BIT, vaddr_tlb_idx, vaddr_tlb_idx, TCGv::new_imm(0xfff)));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SLL_64BIT, vaddr_tlb_idx, vaddr_tlb_idx, TCGv::new_imm(3)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SRL_64BIT,
+            vaddr_tlb_idx,
+            src_addr,
+            TCGv::new_imm(12),
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::AND_64BIT,
+            vaddr_tlb_idx,
+            vaddr_tlb_idx,
+            TCGv::new_imm(0xfff),
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SLL_64BIT,
+            vaddr_tlb_idx,
+            vaddr_tlb_idx,
+            TCGv::new_imm(3),
+        ));
 
         // Make TLB Vaddr Index Address
         tcg_lists.push(TCGOp::new_1op(TCGOpcode::MOVE_STACK, stack_reg));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::ADD_TLBIDX_OFFSET, tlb_byte_addr, stack_reg));  // Relative Addr of TLB
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, vaddr_tlb_idx));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::ADD_TLBIDX_OFFSET,
+            tlb_byte_addr,
+            stack_reg,
+        )); // Relative Addr of TLB
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            vaddr_tlb_idx,
+        ));
 
         // Make VAddr upper bit for compare TLB value
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SRL_64BIT, src_addr, src_addr, TCGv::new_imm(24)));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MEM_LOAD, tlb_byte_addr, tlb_byte_addr));
-        tcg_lists.push(TCGOp::new_2op_with_label(TCGOpcode::CMP_EQ, src_addr, tlb_byte_addr, Rc::clone(&label_tlb_match)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SRL_64BIT,
+            src_addr,
+            src_addr,
+            TCGv::new_imm(24),
+        ));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MEM_LOAD,
+            tlb_byte_addr,
+            tlb_byte_addr,
+        ));
+        tcg_lists.push(TCGOp::new_2op_with_label(
+            TCGOpcode::CMP_EQ,
+            src_addr,
+            tlb_byte_addr,
+            Rc::clone(&label_tlb_match),
+        ));
         // if TLB not hit, jump helper function
-        tcg_lists.push(TCGOp::new_helper_call_arg4(helper_op as usize, 
-                                                   TCGv::new_reg(dest_reg as u64), 
-                                                   TCGv::new_reg(base_reg as u64), 
-                                                   TCGv::new_imm(offset as u64), 
-                                                   TCGv::new_imm(inst.addr)));
+        tcg_lists.push(TCGOp::new_helper_call_arg4(
+            helper_op as usize,
+            TCGv::new_reg(dest_reg as u64),
+            TCGv::new_reg(base_reg as u64),
+            TCGv::new_imm(offset as u64),
+            TCGv::new_imm(inst.addr),
+        ));
 
         let zero = Box::new(TCGv::new_reg(0 as u64));
         let dummy_addr = Box::new(TCGv::new_imm(0));
-        
+
         let label_load_excp = Rc::new(RefCell::new(TCGLabel::new()));
         let tcg_label_load_excp = TCGOp::new_label(Rc::clone(&label_load_excp));
 
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::EQ_EAX_64BIT, src_addr, *zero, *dummy_addr, Rc::clone(&label_load_excp)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::EQ_EAX_64BIT,
+            src_addr,
+            *zero,
+            *dummy_addr,
+            Rc::clone(&label_load_excp),
+        ));
         tcg_lists.push(TCGOp::new_0op(TCGOpcode::EXIT_TB, None));
 
         // Extract lower 12bit address and add with TLB address
         tcg_lists.push(tcg_label_tlb_match);
         tcg_lists.push(TCGOp::new_1op(TCGOpcode::MOVE_STACK, stack_reg));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::ADD_TLBADDR_OFFSET, tlb_byte_addr, stack_reg));  // Relative Addr of TLB Paddr
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, vaddr_tlb_idx));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MEM_LOAD, tlb_byte_addr, tlb_byte_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, vaddr_low12bit));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, TCGv::new_imm(0x80000000)));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::ADD_MEM_OFFSET, tlb_byte_addr, tlb_byte_addr));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::ADD_TLBADDR_OFFSET,
+            tlb_byte_addr,
+            stack_reg,
+        )); // Relative Addr of TLB Paddr
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            vaddr_tlb_idx,
+        ));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MEM_LOAD,
+            tlb_byte_addr,
+            tlb_byte_addr,
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            vaddr_low12bit,
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            TCGv::new_imm(0x80000000),
+        ));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::ADD_MEM_OFFSET,
+            tlb_byte_addr,
+            tlb_byte_addr,
+        ));
         tcg_lists.push(TCGOp::new_2op(load_op, tlb_byte_addr, tlb_byte_addr));
         tcg_lists.push(TCGOp::tcg_set_gpr(dest_reg, tlb_byte_addr));
         tcg_lists.push(tcg_label_load_excp);
 
-        self.tcg_temp_free(src_addr      );
+        self.tcg_temp_free(src_addr);
         self.tcg_temp_free(vaddr_low12bit);
-        self.tcg_temp_free(vaddr_tlb_idx );
-        self.tcg_temp_free(stack_reg     );
-        self.tcg_temp_free(tlb_byte_addr );
+        self.tcg_temp_free(vaddr_tlb_idx);
+        self.tcg_temp_free(stack_reg);
+        self.tcg_temp_free(tlb_byte_addr);
 
         return tcg_lists;
     }
-    fn translate_load(&mut self, inst: &InstrInfo, load_op: TCGOpcode, helper_op: CALL_HELPER_IDX) -> Vec<TCGOp> {
+    fn translate_load(
+        &mut self,
+        inst: &InstrInfo,
+        load_op: TCGOpcode,
+        helper_op: CALL_HELPER_IDX,
+    ) -> Vec<TCGOp> {
         let rs1_addr = get_rs1_addr!(inst.inst);
         let imm_const: u64 = ((inst.inst as i32) >> 20) as u64;
         let rd_addr = get_rd_addr!(inst.inst);
@@ -254,33 +349,65 @@ impl TranslateRiscv {
     }
 
     pub fn translate_ld(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_load(inst, TCGOpcode::LOAD_64BIT, CALL_HELPER_IDX::CALL_LOAD64_IDX)
+        self.translate_load(
+            inst,
+            TCGOpcode::LOAD_64BIT,
+            CALL_HELPER_IDX::CALL_LOAD64_IDX,
+        )
     }
     pub fn translate_lw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_load(inst, TCGOpcode::LOAD_32BIT, CALL_HELPER_IDX::CALL_LOAD32_IDX)
+        self.translate_load(
+            inst,
+            TCGOpcode::LOAD_32BIT,
+            CALL_HELPER_IDX::CALL_LOAD32_IDX,
+        )
     }
     pub fn translate_lh(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_load(inst, TCGOpcode::LOAD_16BIT, CALL_HELPER_IDX::CALL_LOAD16_IDX)
+        self.translate_load(
+            inst,
+            TCGOpcode::LOAD_16BIT,
+            CALL_HELPER_IDX::CALL_LOAD16_IDX,
+        )
     }
     pub fn translate_lb(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         self.translate_load(inst, TCGOpcode::LOAD_8BIT, CALL_HELPER_IDX::CALL_LOAD8_IDX)
     }
     pub fn translate_lwu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_load(inst, TCGOpcode::LOADU_32BIT, CALL_HELPER_IDX::CALL_LOADU32_IDX)
+        self.translate_load(
+            inst,
+            TCGOpcode::LOADU_32BIT,
+            CALL_HELPER_IDX::CALL_LOADU32_IDX,
+        )
     }
     pub fn translate_lhu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_load(inst, TCGOpcode::LOADU_16BIT, CALL_HELPER_IDX::CALL_LOADU16_IDX)
+        self.translate_load(
+            inst,
+            TCGOpcode::LOADU_16BIT,
+            CALL_HELPER_IDX::CALL_LOADU16_IDX,
+        )
     }
     pub fn translate_lbu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_load(inst, TCGOpcode::LOADU_8BIT, CALL_HELPER_IDX::CALL_LOADU8_IDX)
+        self.translate_load(
+            inst,
+            TCGOpcode::LOADU_8BIT,
+            CALL_HELPER_IDX::CALL_LOADU8_IDX,
+        )
     }
 
-    pub fn translate_raw_store(&mut self, base_reg: u32, offset: u64, dest_reg: u32, inst: &InstrInfo, store_op: TCGOpcode, helper_op: CALL_HELPER_IDX) -> Vec<TCGOp> {
-        let src_addr       = self.tcg_temp_new();
+    pub fn translate_raw_store(
+        &mut self,
+        base_reg: u32,
+        offset: u64,
+        dest_reg: u32,
+        inst: &InstrInfo,
+        store_op: TCGOpcode,
+        helper_op: CALL_HELPER_IDX,
+    ) -> Vec<TCGOp> {
+        let src_addr = self.tcg_temp_new();
         let vaddr_low12bit = self.tcg_temp_new();
-        let vaddr_tlb_idx  = self.tcg_temp_new();
-        let stack_reg      = self.tcg_temp_new();
-        let tlb_byte_addr  = self.tcg_temp_new();
+        let vaddr_tlb_idx = self.tcg_temp_new();
+        let stack_reg = self.tcg_temp_new();
+        let tlb_byte_addr = self.tcg_temp_new();
 
         let label_tlb_match = Rc::new(RefCell::new(TCGLabel::new()));
         let tcg_label_tlb_match = TCGOp::new_label(Rc::clone(&label_tlb_match));
@@ -291,86 +418,195 @@ impl TranslateRiscv {
         tcg_lists.push(TCGOp::tcg_get_gpr(src_addr, base_reg));
         // Extract TLB Index and offset
         if offset != 0 {
-            tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, src_addr, src_addr, TCGv::new_imm(offset as u64)));
+            tcg_lists.push(TCGOp::new_3op(
+                TCGOpcode::ADD_64BIT,
+                src_addr,
+                src_addr,
+                TCGv::new_imm(offset as u64),
+            ));
         }
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::AND_64BIT, vaddr_low12bit, src_addr, TCGv::new_imm(0xfff)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::AND_64BIT,
+            vaddr_low12bit,
+            src_addr,
+            TCGv::new_imm(0xfff),
+        ));
 
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SRL_64BIT, vaddr_tlb_idx, src_addr, TCGv::new_imm(12)));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::AND_64BIT, vaddr_tlb_idx, vaddr_tlb_idx, TCGv::new_imm(0xfff)));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SLL_64BIT, vaddr_tlb_idx, vaddr_tlb_idx, TCGv::new_imm(3)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SRL_64BIT,
+            vaddr_tlb_idx,
+            src_addr,
+            TCGv::new_imm(12),
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::AND_64BIT,
+            vaddr_tlb_idx,
+            vaddr_tlb_idx,
+            TCGv::new_imm(0xfff),
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SLL_64BIT,
+            vaddr_tlb_idx,
+            vaddr_tlb_idx,
+            TCGv::new_imm(3),
+        ));
 
         // Make TLB Vaddr Index Address
         tcg_lists.push(TCGOp::new_1op(TCGOpcode::MOVE_STACK, stack_reg));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::ADD_TLBIDX_OFFSET, tlb_byte_addr, stack_reg));  // Relative Addr of TLB
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, vaddr_tlb_idx));
-// 
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::ADD_TLBIDX_OFFSET,
+            tlb_byte_addr,
+            stack_reg,
+        )); // Relative Addr of TLB
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            vaddr_tlb_idx,
+        ));
+        //
         // Make VAddr upper bit for compare TLB value
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::SRL_64BIT, src_addr, src_addr, TCGv::new_imm(24)));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MEM_LOAD, tlb_byte_addr, tlb_byte_addr));
-        tcg_lists.push(TCGOp::new_2op_with_label(TCGOpcode::CMP_EQ, src_addr, tlb_byte_addr, Rc::clone(&label_tlb_match)));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::SRL_64BIT,
+            src_addr,
+            src_addr,
+            TCGv::new_imm(24),
+        ));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MEM_LOAD,
+            tlb_byte_addr,
+            tlb_byte_addr,
+        ));
+        tcg_lists.push(TCGOp::new_2op_with_label(
+            TCGOpcode::CMP_EQ,
+            src_addr,
+            tlb_byte_addr,
+            Rc::clone(&label_tlb_match),
+        ));
         // if TLB not hit, jump helper function
-        tcg_lists.push(TCGOp::new_helper_call_arg4(helper_op as usize, 
-                                                            TCGv::new_reg(dest_reg as u64), 
-                                                            TCGv::new_reg(base_reg as u64), 
-                                                            TCGv::new_imm(offset as u64), 
-                                                            TCGv::new_imm(inst.addr)));
+        tcg_lists.push(TCGOp::new_helper_call_arg4(
+            helper_op as usize,
+            TCGv::new_reg(dest_reg as u64),
+            TCGv::new_reg(base_reg as u64),
+            TCGv::new_imm(offset as u64),
+            TCGv::new_imm(inst.addr),
+        ));
 
         let zero = Box::new(TCGv::new_reg(0 as u64));
         let dummy_addr = Box::new(TCGv::new_imm(0));
-        
+
         let label_load_excp = Rc::new(RefCell::new(TCGLabel::new()));
         let tcg_label_load_excp = TCGOp::new_label(Rc::clone(&label_load_excp));
 
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::EQ_EAX_64BIT, src_addr, *zero, *dummy_addr, Rc::clone(&label_load_excp)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::EQ_EAX_64BIT,
+            src_addr,
+            *zero,
+            *dummy_addr,
+            Rc::clone(&label_load_excp),
+        ));
         tcg_lists.push(TCGOp::new_0op(TCGOpcode::EXIT_TB, None));
-        self.tcg_temp_free(src_addr      );
+        self.tcg_temp_free(src_addr);
 
         // Extract lower 12bit address and add with TLB address
         tcg_lists.push(tcg_label_tlb_match);
         tcg_lists.push(TCGOp::new_1op(TCGOpcode::MOVE_STACK, stack_reg));
-        self.tcg_temp_free(stack_reg     );
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::ADD_TLBADDR_OFFSET, tlb_byte_addr, stack_reg));  // Relative Addr of TLB Paddr
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, vaddr_tlb_idx));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MEM_LOAD, tlb_byte_addr, tlb_byte_addr));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, vaddr_low12bit));
-        tcg_lists.push(TCGOp::new_3op(TCGOpcode::ADD_64BIT, tlb_byte_addr, tlb_byte_addr, TCGv::new_imm(0x80000000)));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::ADD_MEM_OFFSET, tlb_byte_addr, tlb_byte_addr));
+        self.tcg_temp_free(stack_reg);
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::ADD_TLBADDR_OFFSET,
+            tlb_byte_addr,
+            stack_reg,
+        )); // Relative Addr of TLB Paddr
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            vaddr_tlb_idx,
+        ));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MEM_LOAD,
+            tlb_byte_addr,
+            tlb_byte_addr,
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            vaddr_low12bit,
+        ));
+        tcg_lists.push(TCGOp::new_3op(
+            TCGOpcode::ADD_64BIT,
+            tlb_byte_addr,
+            tlb_byte_addr,
+            TCGv::new_imm(0x80000000),
+        ));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::ADD_MEM_OFFSET,
+            tlb_byte_addr,
+            tlb_byte_addr,
+        ));
         let rs2_data = self.tcg_temp_new();
         tcg_lists.push(TCGOp::tcg_get_gpr(rs2_data, dest_reg));
         tcg_lists.push(TCGOp::new_2op(store_op, rs2_data, tlb_byte_addr));
         tcg_lists.push(tcg_label_load_excp);
 
         self.tcg_temp_free(vaddr_low12bit);
-        self.tcg_temp_free(vaddr_tlb_idx );
-        self.tcg_temp_free(tlb_byte_addr );
+        self.tcg_temp_free(vaddr_tlb_idx);
+        self.tcg_temp_free(tlb_byte_addr);
         self.tcg_temp_free(rs2_data);
-        
+
         return tcg_lists;
     }
 
-
-    fn translate_store(&mut self, inst: &InstrInfo, store_op: TCGOpcode, helper_op: CALL_HELPER_IDX) -> Vec<TCGOp> {
+    fn translate_store(
+        &mut self,
+        inst: &InstrInfo,
+        store_op: TCGOpcode,
+        helper_op: CALL_HELPER_IDX,
+    ) -> Vec<TCGOp> {
         let rs1_addr = get_rs1_addr!(inst.inst);
         let imm_const: u64 = get_s_imm_field!(inst.inst);
         let imm_const = ((imm_const as i32) << (32 - 12)) >> (32 - 12);
         let rs2_addr = get_rs2_addr!(inst.inst);
 
-        self.translate_raw_store(rs1_addr, imm_const as u64, rs2_addr, inst, store_op, helper_op)
+        self.translate_raw_store(
+            rs1_addr,
+            imm_const as u64,
+            rs2_addr,
+            inst,
+            store_op,
+            helper_op,
+        )
     }
 
     pub fn translate_sd(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_store(inst, TCGOpcode::STORE_64BIT, CALL_HELPER_IDX::CALL_STORE64_IDX)
+        self.translate_store(
+            inst,
+            TCGOpcode::STORE_64BIT,
+            CALL_HELPER_IDX::CALL_STORE64_IDX,
+        )
     }
     pub fn translate_sw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_store(inst, TCGOpcode::STORE_32BIT, CALL_HELPER_IDX::CALL_STORE32_IDX)
+        self.translate_store(
+            inst,
+            TCGOpcode::STORE_32BIT,
+            CALL_HELPER_IDX::CALL_STORE32_IDX,
+        )
     }
     pub fn translate_sh(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_store(inst, TCGOpcode::STORE_16BIT, CALL_HELPER_IDX::CALL_STORE16_IDX)
+        self.translate_store(
+            inst,
+            TCGOpcode::STORE_16BIT,
+            CALL_HELPER_IDX::CALL_STORE16_IDX,
+        )
     }
     pub fn translate_sb(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        self.translate_store(inst, TCGOpcode::STORE_8BIT, CALL_HELPER_IDX::CALL_STORE8_IDX)
+        self.translate_store(
+            inst,
+            TCGOpcode::STORE_8BIT,
+            CALL_HELPER_IDX::CALL_STORE8_IDX,
+        )
     }
-
 
     pub fn translate_slli(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         self.translate_shift_i(TCGOpcode::SLL_64BIT, inst)
@@ -423,7 +659,6 @@ impl TranslateRiscv {
         self.translate_rri(TCGOpcode::SLTU_64BIT, inst)
     }
 
-
     pub fn translate_mul(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         self.translate_rrr(TCGOpcode::MUL_64BIT, inst)
     }
@@ -440,7 +675,14 @@ impl TranslateRiscv {
         self.translate_rrr(TCGOpcode::MUL_32BIT, inst)
     }
 
-    fn translate_div_common (&mut self, op: TCGOpcode, rd_addr: u32, rs1_addr: u32, rs2_addr: u32, inst: &InstrInfo) -> Vec<TCGOp> {
+    fn translate_div_common(
+        &mut self,
+        op: TCGOpcode,
+        rd_addr: u32,
+        rs1_addr: u32,
+        rs2_addr: u32,
+        inst: &InstrInfo,
+    ) -> Vec<TCGOp> {
         if rd_addr == 0 {
             return vec![];
         }
@@ -455,45 +697,97 @@ impl TranslateRiscv {
         let source1 = self.tcg_temp_new();
         let source2 = self.tcg_temp_new();
 
-        tcg_lists.push(TCGOp::tcg_get_gpr(source1, rs1_addr)); 
+        tcg_lists.push(TCGOp::tcg_get_gpr(source1, rs1_addr));
         tcg_lists.push(TCGOp::tcg_get_gpr(source2, rs2_addr));
 
         // when source2 == zero, doesn't execute.
         let zero = self.tcg_temp_new();
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MOV_IMM_64BIT, zero, TCGv::new_imm(0)));
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::CMP_EQ, source2, zero, TCGv::new_imm(0), Rc::clone(&label_src2_zero_fail)));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MOV_IMM_64BIT,
+            zero,
+            TCGv::new_imm(0),
+        ));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::CMP_EQ,
+            source2,
+            zero,
+            TCGv::new_imm(0),
+            Rc::clone(&label_src2_zero_fail),
+        ));
         self.tcg_temp_free(zero);
 
         // when source1 == 8000_0000_0000_0000, doesn't execute.
         let minus1 = self.tcg_temp_new();
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MOV_IMM_64BIT, minus1, TCGv::new_imm(0x8000_0000_0000_0000)));
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::CMP_EQ, source1, minus1, TCGv::new_imm(0), Rc::clone(&label_cond1_fail)));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MOV_IMM_64BIT,
+            minus1,
+            TCGv::new_imm(0x8000_0000_0000_0000),
+        ));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::CMP_EQ,
+            source1,
+            minus1,
+            TCGv::new_imm(0),
+            Rc::clone(&label_cond1_fail),
+        ));
         self.tcg_temp_free(minus1);
 
         tcg_lists.push(TCGOp::new_3op(op, source1, source1, source2));
-        tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1)); 
+        tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         // Actually this is no conditional jump
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::CMP_EQ, source1, source1, TCGv::new_imm(0), Rc::clone(&label_finish)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::CMP_EQ,
+            source1,
+            source1,
+            TCGv::new_imm(0),
+            Rc::clone(&label_finish),
+        ));
 
         let zero = self.tcg_temp_new();
         tcg_lists.push(TCGOp::new_label(Rc::clone(&label_cond1_fail)));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MOV_IMM_64BIT, zero, TCGv::new_imm((0 - 1) as u64)));
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::CMP_EQ, source2, zero, TCGv::new_imm(0), Rc::clone(&label_cond2_fail)));
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MOV_IMM_64BIT,
+            zero,
+            TCGv::new_imm((0 - 1) as u64),
+        ));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::CMP_EQ,
+            source2,
+            zero,
+            TCGv::new_imm(0),
+            Rc::clone(&label_cond2_fail),
+        ));
         self.tcg_temp_free(zero);
 
         tcg_lists.push(TCGOp::new_3op(op, source1, source1, source2));
-        tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1)); 
+        tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, source1));
         // Actually this is no conditional jump
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::CMP_EQ, source1, source1, TCGv::new_imm(0), Rc::clone(&label_finish)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::CMP_EQ,
+            source1,
+            source1,
+            TCGv::new_imm(0),
+            Rc::clone(&label_finish),
+        ));
 
         tcg_lists.push(TCGOp::new_label(Rc::clone(&label_cond2_fail)));
         // Actually this is no conditional jump
-        tcg_lists.push(TCGOp::new_4op(TCGOpcode::CMP_EQ, source1, source1, TCGv::new_imm(0), Rc::clone(&label_finish)));
+        tcg_lists.push(TCGOp::new_4op(
+            TCGOpcode::CMP_EQ,
+            source1,
+            source1,
+            TCGv::new_imm(0),
+            Rc::clone(&label_finish),
+        ));
 
         let minus1 = self.tcg_temp_new();
         tcg_lists.push(TCGOp::new_label(Rc::clone(&label_src2_zero_fail)));
-        tcg_lists.push(TCGOp::new_2op(TCGOpcode::MOV_IMM_64BIT, minus1, TCGv::new_imm((0 - 1) as u64)));
-        tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, minus1)); 
+        tcg_lists.push(TCGOp::new_2op(
+            TCGOpcode::MOV_IMM_64BIT,
+            minus1,
+            TCGv::new_imm((0 - 1) as u64),
+        ));
+        tcg_lists.push(TCGOp::tcg_set_gpr(rd_addr, minus1));
         self.tcg_temp_free(minus1);
 
         tcg_lists.push(TCGOp::new_label(Rc::clone(&label_finish)));
@@ -505,18 +799,18 @@ impl TranslateRiscv {
     }
 
     pub fn translate_div(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
-        let rs2_addr= get_rs2_addr!(inst.inst);
-        let rd_addr = get_rd_addr!(inst.inst); 
+        let rs1_addr = get_rs1_addr!(inst.inst);
+        let rs2_addr = get_rs2_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
 
-        self.translate_div_common (TCGOpcode::DIV_64BIT, rd_addr, rs1_addr, rs2_addr, inst)
+        self.translate_div_common(TCGOpcode::DIV_64BIT, rd_addr, rs1_addr, rs2_addr, inst)
     }
     pub fn translate_divu(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
-        let rs1_addr= get_rs1_addr!(inst.inst);
-        let rs2_addr= get_rs2_addr!(inst.inst);
-        let rd_addr = get_rd_addr!(inst.inst); 
+        let rs1_addr = get_rs1_addr!(inst.inst);
+        let rs2_addr = get_rs2_addr!(inst.inst);
+        let rd_addr = get_rd_addr!(inst.inst);
 
-        self.translate_div_common (TCGOpcode::DIVU_64BIT, rd_addr, rs1_addr, rs2_addr, inst)
+        self.translate_div_common(TCGOpcode::DIVU_64BIT, rd_addr, rs1_addr, rs2_addr, inst)
     }
     pub fn translate_divw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         self.translate_rrr(TCGOpcode::DIV_32BIT, inst)
@@ -537,5 +831,4 @@ impl TranslateRiscv {
     pub fn translate_remuw(&mut self, inst: &InstrInfo) -> Vec<TCGOp> {
         self.translate_rrr(TCGOpcode::REMU_32BIT, inst)
     }
-
 }

--- a/src/target/riscv/translate_riscv_priv.rs
+++ b/src/target/riscv/translate_riscv_priv.rs
@@ -1,9 +1,9 @@
-use super::super::super::tcg::tcg::{TCGOp, TCGOpcode, TCGv};
 use super::super::super::instr_info::InstrInfo;
+use super::super::super::tcg::tcg::{TCGOp, TCGOpcode, TCGv};
 use super::riscv::CALL_HELPER_IDX;
 
-use super::super::super::get_rs1_addr;
 use super::super::super::get_rd_addr;
+use super::super::super::get_rs1_addr;
 
 use super::riscv::TranslateRiscv;
 
@@ -117,5 +117,4 @@ impl TranslateRiscv {
         let exit_tb = TCGOp::new_0op(TCGOpcode::EXIT_TB, None);
         vec![mret_op, exit_tb]
     }
-
 }

--- a/src/tcg/mod.rs
+++ b/src/tcg/mod.rs
@@ -1,2 +1,2 @@
-pub mod x86;
 pub mod tcg;
+pub mod x86;

--- a/src/tcg/tcg.rs
+++ b/src/tcg/tcg.rs
@@ -78,10 +78,10 @@ pub enum TCGOpcode {
     SGNJ_64BIT,
     SGNJN_64BIT,
     SGNJX_64BIT,
-    
+
     SGNJ_32BIT,
     SGNJN_32BIT,
-    SGNJX_32BIT,   
+    SGNJX_32BIT,
 
     MUL_64BIT,
     MULH_64BIT,
@@ -146,7 +146,7 @@ pub enum RegisterType {
 }
 
 impl TCGOp {
-    pub fn tcg_get_gpr (dest: TCGv, reg_addr: u32) -> TCGOp {
+    pub fn tcg_get_gpr(dest: TCGv, reg_addr: u32) -> TCGOp {
         assert_eq!(dest.t, TCGvType::TCGTemp);
         TCGOp {
             op: Some(TCGOpcode::GET_GPR),
@@ -155,11 +155,11 @@ impl TCGOp {
             arg2: None,
             arg3: None,
             label: None,
-            helper_idx: 0   
+            helper_idx: 0,
         }
     }
 
-    pub fn tcg_set_gpr (reg_addr: u32, source: TCGv) -> TCGOp {
+    pub fn tcg_set_gpr(reg_addr: u32, source: TCGv) -> TCGOp {
         assert_eq!(source.t, TCGvType::TCGTemp);
         TCGOp {
             op: Some(TCGOpcode::SET_GPR),
@@ -168,7 +168,7 @@ impl TCGOp {
             arg2: None,
             arg3: None,
             label: None,
-            helper_idx: 0   
+            helper_idx: 0,
         }
     }
 
@@ -208,7 +208,12 @@ impl TCGOp {
         }
     }
 
-    pub fn new_2op_with_label(opcode: TCGOpcode, a1: TCGv, a2: TCGv, label: Rc<RefCell<TCGLabel>>) -> TCGOp {
+    pub fn new_2op_with_label(
+        opcode: TCGOpcode,
+        a1: TCGv,
+        a2: TCGv,
+        label: Rc<RefCell<TCGLabel>>,
+    ) -> TCGOp {
         TCGOp {
             op: Some(opcode),
             arg0: Some(a1),
@@ -232,7 +237,13 @@ impl TCGOp {
         }
     }
 
-    pub fn new_4op(opcode: TCGOpcode, a1: TCGv, a2: TCGv, a3: TCGv, label: Rc<RefCell<TCGLabel>>) -> TCGOp {
+    pub fn new_4op(
+        opcode: TCGOpcode,
+        a1: TCGv,
+        a2: TCGv,
+        a3: TCGv,
+        label: Rc<RefCell<TCGLabel>>,
+    ) -> TCGOp {
         TCGOp {
             op: Some(opcode),
             arg0: Some(a1),
@@ -359,7 +370,7 @@ impl TCGv {
 
     pub fn new_temp(val: u64) -> TCGv {
         TCGv {
-            t: TCGvType::TCGTemp, 
+            t: TCGvType::TCGTemp,
             value: val,
         }
     }
@@ -387,18 +398,40 @@ pub trait TCG {
     fn tcg_gen_set_gpr(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
 
     fn tcg_gen_move_stack(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_mem_load(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType) -> usize;
-    fn tcg_gen_mem_store(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType) -> usize;
+    fn tcg_gen_mem_load(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+    ) -> usize;
+    fn tcg_gen_mem_store(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+    ) -> usize;
 
-    fn tcg_gen_tlbidx_offset(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_tlbaddr_offset(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_tlbidx_offset(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>)
+        -> usize;
+    fn tcg_gen_tlbaddr_offset(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
     fn tcg_gen_mem_offset(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
 
-    fn tcg_gen_add_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_sub_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_and_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_add_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>)
+        -> usize;
+    fn tcg_gen_sub_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>)
+        -> usize;
+    fn tcg_gen_and_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>)
+        -> usize;
     fn tcg_gen_or_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_xor_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_xor_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>)
+        -> usize;
 
     fn tcg_gen_mul_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
     fn tcg_gen_div_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
@@ -414,9 +447,15 @@ pub trait TCG {
     fn tcg_gen_ltu_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
     fn tcg_gen_geu_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
     fn tcg_gen_mov_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_mov_imm_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_mov_imm_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>)
+        -> usize;
 
-    fn tcg_gen_sign_ext_32_64(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_sign_ext_32_64(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
 
     fn tcg_gen_eq_eax_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
 
@@ -435,9 +474,23 @@ pub trait TCG {
     fn tcg_gen_sra_32bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
 
     /* Memory Access */
-    fn tcg_gen_load(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType, target_reg: RegisterType) -> usize;
+    fn tcg_gen_load(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+        target_reg: RegisterType,
+    ) -> usize;
 
-    fn tcg_gen_store(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType, target_reg: RegisterType) -> usize;
+    fn tcg_gen_store(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+        target_reg: RegisterType,
+    ) -> usize;
 
     /* Label Relocation */
     fn tcg_out_reloc(host_code_ptr: usize, label: &Rc<RefCell<TCGLabel>>) -> usize;
@@ -448,12 +501,38 @@ pub trait TCG {
     fn tcg_gen_csrrs(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
     fn tcg_gen_csrrc(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
 
-    fn tcg_gen_helper_call(emu: &mut EmuEnv,arg_size: usize,pc_address: u64,tcg: &TCGOp,mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_helper_call(
+        emu: &mut EmuEnv,
+        arg_size: usize,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
 
-    fn tcg_gen_int_reg_from_float_reg(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_float_reg_from_int_reg(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_int_reg_from_float_reg_32bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
-    fn tcg_gen_float_reg_from_int_reg_32bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
+    fn tcg_gen_int_reg_from_float_reg(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
+    fn tcg_gen_float_reg_from_int_reg(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
+    fn tcg_gen_int_reg_from_float_reg_32bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
+    fn tcg_gen_float_reg_from_int_reg_32bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize;
 
     fn tcg_gen_sgnj_32bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;
     fn tcg_gen_sgnjn_32bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize;

--- a/src/tcg/x86/disassemble.rs
+++ b/src/tcg/x86/disassemble.rs
@@ -1,4 +1,4 @@
-use iced_x86::{Decoder, DecoderOptions, Formatter, Instruction, GasFormatter};
+use iced_x86::{Decoder, DecoderOptions, Formatter, GasFormatter, Instruction};
 
 const EXAMPLE_CODE_BITNESS: u32 = 64;
 const HEXBYTES_COLUMN_BYTE_LENGTH: usize = 10;
@@ -50,5 +50,3 @@ pub fn disassemble_x86(bytes: &[u8], host_code_addr: *const u8) {
         println!(" {}", output);
     }
 }
-
-

--- a/src/tcg/x86/mod.rs
+++ b/src/tcg/x86/mod.rs
@@ -1,2 +1,2 @@
-pub mod x86;
 pub mod disassemble;
+pub mod x86;

--- a/src/tcg/x86/x86.rs
+++ b/src/tcg/x86/x86.rs
@@ -81,15 +81,14 @@ enum X86Opcode {
     ADD_GV_IMM = 0x00_81,
     SUB_GV_IMM = 0x28_81,
     AND_GV_IMM = 0x20_81,
-    OR_GV_IMM  = 0x08_81,
+    OR_GV_IMM = 0x08_81,
     XOR_GV_IMM = 0x30_81,
 
     IMUL_RDX_RAX_R = 0xaf_0f,
     IDIV_RDX_RAX_R = 0x38_f7,
-    DIV_RDX_RAX_R  = 0x30_f7,
+    DIV_RDX_RAX_R = 0x30_f7,
 
     // MOVSXD = 0x63,
-
     CQO = 0x99,
 
     SETB = 0x92_0f, // より下の場合バイトを設定します
@@ -102,11 +101,11 @@ enum X86Opcode {
 #[derive(PartialEq, Debug)]
 #[allow(non_camel_case_types, dead_code)]
 enum X86ModRM {
-    MOD_00_DISP_RAX = (0b00 << 6) | (X86TargetRM::RAX as isize), 
+    MOD_00_DISP_RAX = (0b00 << 6) | (X86TargetRM::RAX as isize),
     MOD_00_DISP_RSI = 0x06,
     MOD_00_DISP_RBP = 0x05,
-    MOD_00_DISP_RCX = (0b00 << 6) | (X86TargetRM::RCX as isize), 
-    MOD_00_DISP_RDX = (0b00 << 6) | (X86TargetRM::RDX as isize), 
+    MOD_00_DISP_RCX = (0b00 << 6) | (X86TargetRM::RCX as isize),
+    MOD_00_DISP_RDX = (0b00 << 6) | (X86TargetRM::RDX as isize),
 
     MOD_01_DISP_RBP = 0x45,
     MOD_10_DISP_RBP = 0x85,
@@ -140,7 +139,12 @@ pub enum X86TargetRM {
 pub struct TCGX86;
 
 impl TCGX86 {
-    fn tcg_modrm_64bit_out(op: X86Opcode, modrm: X86ModRM, tgt_rm: X86TargetRM, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_64bit_out(
+        op: X86Opcode,
+        modrm: X86ModRM,
+        tgt_rm: X86TargetRM,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 16) | (op as u64) << 8 | 0x48,
             3,
@@ -169,7 +173,12 @@ impl TCGX86 {
         return 2;
     }
 
-    fn tcg_modrm_2byte_64bit_out(op: X86Opcode, modrm: X86ModRM, tgt_rm: X86TargetRM, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_2byte_64bit_out(
+        op: X86Opcode,
+        modrm: X86ModRM,
+        tgt_rm: X86TargetRM,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 24) | (op as u64) << 8 | 0x48,
             4,
@@ -178,7 +187,12 @@ impl TCGX86 {
         return 4;
     }
 
-    fn tcg_modrm_2byte_64bit_raw_out(op: X86Opcode, modrm: u8, tgt_rm: u8, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_2byte_64bit_raw_out(
+        op: X86Opcode,
+        modrm: u8,
+        tgt_rm: u8,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 24) | (op as u64) << 8 | 0x48,
             4,
@@ -187,7 +201,12 @@ impl TCGX86 {
         return 4;
     }
 
-    fn tcg_modrm_32bit_out(op: X86Opcode, modrm: X86ModRM, tgt_rm: X86TargetRM, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_32bit_out(
+        op: X86Opcode,
+        modrm: X86ModRM,
+        tgt_rm: X86TargetRM,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 8) | (op as u64) << 0,
             2,
@@ -205,8 +224,12 @@ impl TCGX86 {
         return 2;
     }
 
-
-    fn tcg_modrm_16bit_out(op: X86Opcode, modrm: X86ModRM, tgt_rm: X86TargetRM, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_16bit_out(
+        op: X86Opcode,
+        modrm: X86ModRM,
+        tgt_rm: X86TargetRM,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 16) | (op as u64) << 8 | 0x66,
             3,
@@ -224,7 +247,12 @@ impl TCGX86 {
         return 3;
     }
 
-    fn tcg_modrm_2byte_32bit_out(op: X86Opcode, modrm: X86ModRM, tgt_rm: X86TargetRM, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_2byte_32bit_out(
+        op: X86Opcode,
+        modrm: X86ModRM,
+        tgt_rm: X86TargetRM,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 16) | (op as u64) << 0,
             3,
@@ -233,7 +261,12 @@ impl TCGX86 {
         return 3;
     }
 
-    fn tcg_modrm_2byte_32bit_raw_out(op: X86Opcode, modrm: u8, tgt_rm: u8, mc: &mut Vec<u8>) -> usize {
+    fn tcg_modrm_2byte_32bit_raw_out(
+        op: X86Opcode,
+        modrm: u8,
+        tgt_rm: u8,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_out(
             ((modrm as u64 | ((tgt_rm as u64) << 3)) << 16) | (op as u64) << 0,
             3,
@@ -266,7 +299,12 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_load_gpr_64bit(emu: &EmuEnv, dest: X86TargetRM, source: u64, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_load_gpr_64bit(
+        emu: &EmuEnv,
+        dest: X86TargetRM,
+        source: u64,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let mut gen_size = 0;
         gen_size +=
             Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, dest, mc);
@@ -287,7 +325,12 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_load_gpr_32bit(emu: &EmuEnv, dest: X86TargetRM, source: u64, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_load_gpr_32bit(
+        emu: &EmuEnv,
+        dest: X86TargetRM,
+        source: u64,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let mut gen_size = 0;
         gen_size +=
             Self::tcg_modrm_32bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, dest, mc);
@@ -310,7 +353,12 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_load_fregs_64bit(emu: &EmuEnv, dest: X86TargetRM, source: u64, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_load_fregs_64bit(
+        emu: &EmuEnv,
+        dest: X86TargetRM,
+        source: u64,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let mut gen_size = 0;
         gen_size +=
             Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, dest, mc);
@@ -331,7 +379,12 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_load_fregs_32bit(emu: &EmuEnv, dest: X86TargetRM, source: u64, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_load_fregs_32bit(
+        emu: &EmuEnv,
+        dest: X86TargetRM,
+        source: u64,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let mut gen_size = 0;
         gen_size +=
             Self::tcg_modrm_32bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, dest, mc);
@@ -348,10 +401,15 @@ impl TCGX86 {
         let mut gen_size = 0;
 
         assert_eq!(source, X86TargetRM::RAX);
-        
+
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0xffffffff_00000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
-        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         gen_size +=
             Self::tcg_modrm_64bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_10_DISP_RBP, source, mc);
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(dest) as u64, 4, mc);
@@ -450,7 +508,12 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_shift_r_64bit(_emu: &EmuEnv, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_shift_r_64bit(
+        _emu: &EmuEnv,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src1_reg = tcg.arg1.unwrap();
         let src2_reg = tcg.arg2.unwrap();
@@ -466,22 +529,42 @@ impl TCGX86 {
         let source2_x86reg = Self::convert_x86_reg(src2_reg.value);
 
         if dest_reg.value != src1_reg.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, target_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+                target_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8, X86TargetRM::RCX as u8, mc);
-        gen_size += Self::tcg_modrm_64bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8,
+            X86TargetRM::RCX as u8,
+            mc,
+        );
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
 
         return gen_size;
     }
 
-    fn tcg_gen_shift_i_64bit(_emu: &EmuEnv, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_shift_i_64bit(
+        _emu: &EmuEnv,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src1_reg = tcg.arg1.unwrap();
-        let imm      = tcg.arg2.unwrap();
+        let imm = tcg.arg2.unwrap();
 
         assert_eq!(dest_reg.t, TCGvType::TCGTemp);
         assert_eq!(src1_reg.t, TCGvType::TCGTemp);
-        assert_eq!(imm     .t, TCGvType::Immediate);
+        assert_eq!(imm.t, TCGvType::Immediate);
 
         let mut gen_size: usize = 0;
 
@@ -489,15 +572,30 @@ impl TCGX86 {
         let source1_x86reg = Self::convert_x86_reg(src1_reg.value);
 
         if dest_reg.value != src1_reg.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, target_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+                target_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_64bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, 0 /*target_x86reg as u8 */, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+            0, /*target_x86reg as u8 */
+            mc,
+        );
         gen_size += Self::tcg_out(imm.value as u64, 1, mc);
 
         return gen_size;
     }
 
-    fn tcg_gen_shift_r_32bit(_emu: &EmuEnv, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_shift_r_32bit(
+        _emu: &EmuEnv,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src1_reg = tcg.arg1.unwrap();
         let src2_reg = tcg.arg2.unwrap();
@@ -513,15 +611,35 @@ impl TCGX86 {
         let source2_x86reg = Self::convert_x86_reg(src2_reg.value);
 
         if dest_reg.value != src1_reg.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, target_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+                target_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8, X86TargetRM::RCX as u8, mc);
-        gen_size += Self::tcg_modrm_32bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8,
+            X86TargetRM::RCX as u8,
+            mc,
+        );
+        gen_size += Self::tcg_modrm_32bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
 
         return gen_size;
     }
 
-    fn tcg_gen_shift_i_32bit(_emu: &EmuEnv, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_shift_i_32bit(
+        _emu: &EmuEnv,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src1_reg = tcg.arg1.unwrap();
         let imm = tcg.arg2.unwrap();
@@ -536,9 +654,19 @@ impl TCGX86 {
         let src1_x86reg = Self::convert_x86_reg(src1_reg.value);
 
         if dest_reg.value != src1_reg.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, dest_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+                dest_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_32bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + dest_x86reg as u8, 0, mc);
+        gen_size += Self::tcg_modrm_32bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + dest_x86reg as u8,
+            0,
+            mc,
+        );
         gen_size += Self::tcg_out(imm.value as u64, 1, mc);
 
         return gen_size;
@@ -553,7 +681,12 @@ impl TCGX86 {
         return byte_len;
     }
 
-    fn tcg_gen_jcc(gen_size: usize, x86_op: X86Opcode, mc: &mut Vec<u8>, label: &Rc<RefCell<tcg::TCGLabel>>) -> usize {
+    fn tcg_gen_jcc(
+        gen_size: usize,
+        x86_op: X86Opcode,
+        mc: &mut Vec<u8>,
+        label: &Rc<RefCell<tcg::TCGLabel>>,
+    ) -> usize {
         let mut gen_size = gen_size;
 
         gen_size += Self::tcg_out(x86_op as u64, 2, mc);
@@ -563,7 +696,13 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_cmp_branch(_emu: &EmuEnv, pc_address: u64, x86_op: X86Opcode, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_cmp_branch(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        x86_op: X86Opcode,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let arg0 = tcg.arg0.unwrap();
         let arg1 = tcg.arg1.unwrap();
 
@@ -594,7 +733,13 @@ impl TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_setcc(_emu: &EmuEnv, pc_address: u64, x86_op: X86Opcode, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_setcc(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        x86_op: X86Opcode,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest = tcg.arg0.unwrap();
         let src1 = tcg.arg1.unwrap();
         let src2 = tcg.arg2.unwrap();
@@ -606,16 +751,37 @@ impl TCGX86 {
 
         if src2.t == TCGvType::TCGTemp {
             let src2_x86reg = Self::convert_x86_reg(src2.value);
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::CMP_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, src1_x86reg as u8, mc);
-        } else {  // src2.t == Immediate
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::CMP_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                src1_x86reg as u8,
+                mc,
+            );
+        } else {
+            // src2.t == Immediate
             gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, src2.value, mc);
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::CMP_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, src1_x86reg as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::CMP_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8,
+                src1_x86reg as u8,
+                mc,
+            );
         }
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0, mc); // initialize format RAX
-        gen_size += Self::tcg_modrm_2byte_64bit_out(x86_op, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_2byte_64bit_out(
+            x86_op,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, dest_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8,
+            dest_x86reg as u8,
+            mc,
+        );
 
         return gen_size;
     }
@@ -640,11 +806,17 @@ impl TCGX86 {
             3 => X86TargetRM::RSI,
             4 => X86TargetRM::RDI,
             5 => X86TargetRM::SIB,
-            _ => panic!("Not supported yet")
-        }
+            _ => panic!("Not supported yet"),
+        };
     }
 
-    fn tcg_gen_op_temp(emu: &mut EmuEnv, pc_address: u64, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_op_temp(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let source1_reg = tcg.arg1.unwrap();
         let source2_reg = tcg.arg2.unwrap();
@@ -660,18 +832,34 @@ impl TCGX86 {
         let source1_x86reg = Self::convert_x86_reg(source1_reg.value);
         let source2_x86reg = Self::convert_x86_reg(source2_reg.value);
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8, source1_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8,
+            source1_x86reg as u8,
+            mc,
+        );
 
         emu.m_x86reg_usage_list[source1_x86reg as usize] = None;
 
         gen_size
     }
 
-    fn tcg_gen_add_temp(emu: &mut EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_add_temp(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         Self::tcg_gen_op_temp(emu, pc_address, X86Opcode::ADD_GV_EV, tcg, mc)
     }
 
-    fn tcg_gen_op_temp_imm(emu: &mut EmuEnv, pc_address: u64, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_op_temp_imm(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let source1_reg = tcg.arg1.unwrap();
         let source2_imm = tcg.arg2.unwrap();
@@ -685,20 +873,39 @@ impl TCGX86 {
         let target_x86reg = Self::convert_x86_reg(dest_reg.value);
         let source1_x86reg = Self::convert_x86_reg(source1_reg.value);
 
-        if source2_imm.value >> 32 != 0 && op == X86Opcode::ADD_GV_IMM{
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, X86TargetRM::RAX as u8, mc);    
+        if source2_imm.value >> 32 != 0 && op == X86Opcode::ADD_GV_IMM {
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
             gen_size += Self::tcg_64bit_out(X86Opcode::ADD_EAX_IV, mc);
             gen_size += Self::tcg_out(source2_imm.value, 4, mc);
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, source1_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8,
+                source1_x86reg as u8,
+                mc,
+            );
 
             emu.m_x86reg_usage_list[source1_x86reg as usize] = None;
-
         } else {
             if dest_reg.value != source1_reg.value {
-                gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, target_x86reg as u8, mc);    
+                gen_size += Self::tcg_modrm_64bit_raw_out(
+                    X86Opcode::MOV_GV_EV,
+                    X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+                    target_x86reg as u8,
+                    mc,
+                );
             }
 
-            gen_size += Self::tcg_modrm_64bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, 0, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                op,
+                X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+                0,
+                mc,
+            );
             gen_size += Self::tcg_out(source2_imm.value, 4, mc);
 
             emu.m_x86reg_usage_list[target_x86reg as usize] = None;
@@ -707,8 +914,12 @@ impl TCGX86 {
         gen_size
     }
 
-
-    fn tcg_gen_op_32_temp(pc_address: u64, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_op_32_temp(
+        pc_address: u64,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let source1_reg = tcg.arg1.unwrap();
         let source2_reg = tcg.arg2.unwrap();
@@ -722,12 +933,22 @@ impl TCGX86 {
         let source1_x86reg = Self::convert_x86_reg(source1_reg.value);
         let source2_x86reg = Self::convert_x86_reg(source2_reg.value);
 
-        gen_size += Self::tcg_modrm_32bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8, source1_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_32bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + source2_x86reg as u8,
+            source1_x86reg as u8,
+            mc,
+        );
 
         gen_size
     }
 
-    fn tcg_gen_op_32_temp_imm(pc_address: u64, op: X86Opcode, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_op_32_temp_imm(
+        pc_address: u64,
+        op: X86Opcode,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let source1_reg = tcg.arg1.unwrap();
         let source2_imm = tcg.arg2.unwrap();
@@ -740,12 +961,16 @@ impl TCGX86 {
 
         let source1_x86reg = Self::convert_x86_reg(source1_reg.value);
 
-        gen_size += Self::tcg_modrm_32bit_raw_out(op, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, 0, mc);
+        gen_size += Self::tcg_modrm_32bit_raw_out(
+            op,
+            X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+            0,
+            mc,
+        );
         gen_size += Self::tcg_out(source2_imm.value, 4, mc);
 
         gen_size
     }
-
 }
 
 impl TCG for TCGX86 {
@@ -758,13 +983,23 @@ impl TCG for TCGX86 {
                     TCGOpcode::ADD_TEMP => TCGX86::tcg_gen_add_temp(emu, pc_address, tcg, mc),
 
                     TCGOpcode::MOVE_STACK => TCGX86::tcg_gen_move_stack(emu, pc_address, tcg, mc),
-                    TCGOpcode::MEM_LOAD => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_64BIT),
-                    TCGOpcode::MEM_STORE => TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_64BIT),
+                    TCGOpcode::MEM_LOAD => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_64BIT)
+                    }
+                    TCGOpcode::MEM_STORE => {
+                        TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_64BIT)
+                    }
 
-                    TCGOpcode::ADD_TLBIDX_OFFSET => TCGX86::tcg_gen_tlbidx_offset(emu, pc_address, tcg, mc),             
-                    TCGOpcode::ADD_TLBADDR_OFFSET => TCGX86::tcg_gen_tlbaddr_offset(emu, pc_address, tcg, mc),                    
+                    TCGOpcode::ADD_TLBIDX_OFFSET => {
+                        TCGX86::tcg_gen_tlbidx_offset(emu, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::ADD_TLBADDR_OFFSET => {
+                        TCGX86::tcg_gen_tlbaddr_offset(emu, pc_address, tcg, mc)
+                    }
 
-                    TCGOpcode::ADD_MEM_OFFSET => TCGX86::tcg_gen_mem_offset(emu, pc_address, tcg, mc),
+                    TCGOpcode::ADD_MEM_OFFSET => {
+                        TCGX86::tcg_gen_mem_offset(emu, pc_address, tcg, mc)
+                    }
 
                     TCGOpcode::ADD_64BIT => TCGX86::tcg_gen_add_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::SUB_64BIT => TCGX86::tcg_gen_sub_64bit(emu, pc_address, tcg, mc),
@@ -778,14 +1013,14 @@ impl TCG for TCGX86 {
                     TCGOpcode::MULHSU_64BIT => TCGX86::tcg_gen_mul_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::MUL_32BIT => TCGX86::tcg_gen_mul_64bit(emu, pc_address, tcg, mc),
 
-                    TCGOpcode::DIV_64BIT  => TCGX86::tcg_gen_div_64bit(emu, pc_address, tcg, mc),
+                    TCGOpcode::DIV_64BIT => TCGX86::tcg_gen_div_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::DIVU_64BIT => TCGX86::tcg_gen_divu_64bit(emu, pc_address, tcg, mc),
-                    TCGOpcode::DIV_32BIT  => TCGX86::tcg_gen_div_64bit(emu, pc_address, tcg, mc),
+                    TCGOpcode::DIV_32BIT => TCGX86::tcg_gen_div_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::DIVU_32BIT => TCGX86::tcg_gen_div_64bit(emu, pc_address, tcg, mc),
 
-                    TCGOpcode::REM_64BIT  => TCGX86::tcg_gen_rem_64bit(emu, pc_address, tcg, mc),
+                    TCGOpcode::REM_64BIT => TCGX86::tcg_gen_rem_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::REMU_64BIT => TCGX86::tcg_gen_rem_64bit(emu, pc_address, tcg, mc),
-                    TCGOpcode::REM_32BIT  => TCGX86::tcg_gen_rem_64bit(emu, pc_address, tcg, mc),
+                    TCGOpcode::REM_32BIT => TCGX86::tcg_gen_rem_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::REMU_32BIT => TCGX86::tcg_gen_rem_64bit(emu, pc_address, tcg, mc),
 
                     /* Shift operations */
@@ -812,35 +1047,99 @@ impl TCG for TCGX86 {
                     TCGOpcode::SLT_64BIT => TCGX86::tcg_gen_slt_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::SLTU_64BIT => TCGX86::tcg_gen_sltu_64bit(emu, pc_address, tcg, mc),
 
-                    TCGOpcode::EQ_EAX_64BIT => TCGX86::tcg_gen_eq_eax_64bit(emu, pc_address, tcg, mc),
+                    TCGOpcode::EQ_EAX_64BIT => {
+                        TCGX86::tcg_gen_eq_eax_64bit(emu, pc_address, tcg, mc)
+                    }
 
-                    TCGOpcode::LOAD_64BIT  => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_64BIT  ),
-                    TCGOpcode::LOAD_32BIT  => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_32BIT  ),
-                    TCGOpcode::LOAD_16BIT  => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_16BIT  ),
-                    TCGOpcode::LOAD_8BIT   => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_8BIT   ),
-                    TCGOpcode::LOADU_32BIT => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_U_32BIT),
-                    TCGOpcode::LOADU_16BIT => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_U_16BIT),
-                    TCGOpcode::LOADU_8BIT  => TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_U_8BIT ),
-                    TCGOpcode::STORE_64BIT => TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_64BIT),
-                    TCGOpcode::STORE_32BIT => TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_32BIT),
-                    TCGOpcode::STORE_16BIT => TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_16BIT),
-                    TCGOpcode::STORE_8BIT  => TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_8BIT ),
+                    TCGOpcode::LOAD_64BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_64BIT)
+                    }
+                    TCGOpcode::LOAD_32BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_32BIT)
+                    }
+                    TCGOpcode::LOAD_16BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_16BIT)
+                    }
+                    TCGOpcode::LOAD_8BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_8BIT)
+                    }
+                    TCGOpcode::LOADU_32BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_U_32BIT)
+                    }
+                    TCGOpcode::LOADU_16BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_U_16BIT)
+                    }
+                    TCGOpcode::LOADU_8BIT => {
+                        TCGX86::tcg_gen_mem_load(emu, pc_address, tcg, mc, MemOpType::LOAD_U_8BIT)
+                    }
+                    TCGOpcode::STORE_64BIT => {
+                        TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_64BIT)
+                    }
+                    TCGOpcode::STORE_32BIT => {
+                        TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_32BIT)
+                    }
+                    TCGOpcode::STORE_16BIT => {
+                        TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_16BIT)
+                    }
+                    TCGOpcode::STORE_8BIT => {
+                        TCGX86::tcg_gen_mem_store(emu, pc_address, tcg, mc, MemOpType::STORE_8BIT)
+                    }
 
-                    TCGOpcode::LOAD_FLOAT_64BIT => TCGX86::tcg_gen_load( emu, pc_address, tcg, mc, MemOpType::LOAD_64BIT, RegisterType::FloatRegister),
-                    TCGOpcode::LOAD_FLOAT_32BIT => TCGX86::tcg_gen_load( emu, pc_address, tcg, mc, MemOpType::LOAD_32BIT, RegisterType::FloatRegister),
+                    TCGOpcode::LOAD_FLOAT_64BIT => TCGX86::tcg_gen_load(
+                        emu,
+                        pc_address,
+                        tcg,
+                        mc,
+                        MemOpType::LOAD_64BIT,
+                        RegisterType::FloatRegister,
+                    ),
+                    TCGOpcode::LOAD_FLOAT_32BIT => TCGX86::tcg_gen_load(
+                        emu,
+                        pc_address,
+                        tcg,
+                        mc,
+                        MemOpType::LOAD_32BIT,
+                        RegisterType::FloatRegister,
+                    ),
 
-                    TCGOpcode::STORE_FLOAT_64BIT => TCGX86::tcg_gen_store( emu, pc_address, tcg, mc, MemOpType::STORE_64BIT, RegisterType::FloatRegister),
-                    TCGOpcode::STORE_FLOAT_32BIT => TCGX86::tcg_gen_store( emu, pc_address, tcg, mc, MemOpType::STORE_32BIT, RegisterType::FloatRegister),
+                    TCGOpcode::STORE_FLOAT_64BIT => TCGX86::tcg_gen_store(
+                        emu,
+                        pc_address,
+                        tcg,
+                        mc,
+                        MemOpType::STORE_64BIT,
+                        RegisterType::FloatRegister,
+                    ),
+                    TCGOpcode::STORE_FLOAT_32BIT => TCGX86::tcg_gen_store(
+                        emu,
+                        pc_address,
+                        tcg,
+                        mc,
+                        MemOpType::STORE_32BIT,
+                        RegisterType::FloatRegister,
+                    ),
 
-                    TCGOpcode::MOVE_TO_INT_FROM_FLOAT => { TCGX86::tcg_gen_int_reg_from_float_reg(emu, pc_address, tcg, mc) }
-                    TCGOpcode::MOVE_TO_FLOAT_FROM_INT => { TCGX86::tcg_gen_float_reg_from_int_reg(emu, pc_address, tcg, mc) }
-                    TCGOpcode::MOVE_TO_INT_FROM_FLOAT_32BIT => { TCGX86::tcg_gen_int_reg_from_float_reg_32bit(emu, pc_address, tcg, mc) }
-                    TCGOpcode::MOVE_TO_FLOAT_FROM_INT_32BIT => { TCGX86::tcg_gen_float_reg_from_int_reg_32bit(emu, pc_address, tcg, mc) }
+                    TCGOpcode::MOVE_TO_INT_FROM_FLOAT => {
+                        TCGX86::tcg_gen_int_reg_from_float_reg(emu, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::MOVE_TO_FLOAT_FROM_INT => {
+                        TCGX86::tcg_gen_float_reg_from_int_reg(emu, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::MOVE_TO_INT_FROM_FLOAT_32BIT => {
+                        TCGX86::tcg_gen_int_reg_from_float_reg_32bit(emu, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::MOVE_TO_FLOAT_FROM_INT_32BIT => {
+                        TCGX86::tcg_gen_float_reg_from_int_reg_32bit(emu, pc_address, tcg, mc)
+                    }
 
-                    TCGOpcode::MOV_IMM_64BIT => TCGX86::tcg_gen_mov_imm_64bit(emu, pc_address, tcg, mc),
+                    TCGOpcode::MOV_IMM_64BIT => {
+                        TCGX86::tcg_gen_mov_imm_64bit(emu, pc_address, tcg, mc)
+                    }
                     TCGOpcode::MOV_64BIT => TCGX86::tcg_gen_mov_64bit(emu, pc_address, tcg, mc),
 
-                    TCGOpcode::SIGN_EXT_32_64 => TCGX86::tcg_gen_sign_ext_32_64(emu, pc_address, tcg, mc),
+                    TCGOpcode::SIGN_EXT_32_64 => {
+                        TCGX86::tcg_gen_sign_ext_32_64(emu, pc_address, tcg, mc)
+                    }
 
                     TCGOpcode::SGNJ_64BIT => TCGX86::tcg_gen_sgnj_64bit(emu, pc_address, tcg, mc),
                     TCGOpcode::SGNJN_64BIT => TCGX86::tcg_gen_sgnjn_64bit(emu, pc_address, tcg, mc),
@@ -850,14 +1149,26 @@ impl TCG for TCGX86 {
                     TCGOpcode::SGNJN_32BIT => TCGX86::tcg_gen_sgnjn_32bit(emu, pc_address, tcg, mc),
                     TCGOpcode::SGNJX_32BIT => TCGX86::tcg_gen_sgnjx_32bit(emu, pc_address, tcg, mc),
 
-                    TCGOpcode::HELPER_CALL_ARG0 => { TCGX86::tcg_gen_helper_call(emu, 0, pc_address, tcg, mc) }
-                    TCGOpcode::HELPER_CALL_ARG1 => { TCGX86::tcg_gen_helper_call(emu, 1, pc_address, tcg, mc) }
-                    TCGOpcode::HELPER_CALL_ARG2 => { TCGX86::tcg_gen_helper_call(emu, 2, pc_address, tcg, mc) }
-                    TCGOpcode::HELPER_CALL_ARG3 => { TCGX86::tcg_gen_helper_call(emu, 3, pc_address, tcg, mc) }
-                    TCGOpcode::HELPER_CALL_ARG4 => { TCGX86::tcg_gen_helper_call(emu, 4, pc_address, tcg, mc) }
-                    TCGOpcode::CMP_EQ => { TCGX86::tcg_gen_cmp_eq(emu, pc_address, tcg, mc) }
-                    TCGOpcode::TLB_MATCH_CHECK => { TCGX86::tcg_gen_match_check(emu, pc_address, tcg, mc) }
-                    
+                    TCGOpcode::HELPER_CALL_ARG0 => {
+                        TCGX86::tcg_gen_helper_call(emu, 0, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::HELPER_CALL_ARG1 => {
+                        TCGX86::tcg_gen_helper_call(emu, 1, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::HELPER_CALL_ARG2 => {
+                        TCGX86::tcg_gen_helper_call(emu, 2, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::HELPER_CALL_ARG3 => {
+                        TCGX86::tcg_gen_helper_call(emu, 3, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::HELPER_CALL_ARG4 => {
+                        TCGX86::tcg_gen_helper_call(emu, 4, pc_address, tcg, mc)
+                    }
+                    TCGOpcode::CMP_EQ => TCGX86::tcg_gen_cmp_eq(emu, pc_address, tcg, mc),
+                    TCGOpcode::TLB_MATCH_CHECK => {
+                        TCGX86::tcg_gen_match_check(emu, pc_address, tcg, mc)
+                    }
+
                     TCGOpcode::EXIT_TB => TCGX86::tcg_exit_tb(emu, pc_address, tcg, mc),
                 };
             }
@@ -868,7 +1179,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_get_gpr(emu: &mut EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_get_gpr(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_tmp = tcg.arg0.unwrap();
         let src_reg = tcg.arg1.unwrap();
 
@@ -879,41 +1195,73 @@ impl TCG for TCGX86 {
         let mut gen_size = pc_address as usize;
 
         if emu.m_arg_config.opt_reg_fwd {
-            if emu.m_gpr_usage_list[src_reg.value as usize].is_some() && emu.m_x86reg_usage_list[target_x86reg as usize].is_some() {
+            if emu.m_gpr_usage_list[src_reg.value as usize].is_some()
+                && emu.m_x86reg_usage_list[target_x86reg as usize].is_some()
+            {
                 let x86_used_reg = emu.m_gpr_usage_list[src_reg.value as usize].unwrap();
                 let gpr_reg = emu.m_x86reg_usage_list[target_x86reg as usize].unwrap();
                 if !(gpr_reg == src_reg.value && x86_used_reg == target_x86reg) {
                     let gpr_relat_address = emu.calc_gpr_relat_address(src_reg.value) as u64;
                     if gpr_relat_address < 128 {
-                        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_01_DISP_RBP, target_x86reg, mc);
-                        gen_size += Self::tcg_out(gpr_relat_address, 1, mc);    
+                        gen_size += Self::tcg_modrm_64bit_out(
+                            X86Opcode::MOV_GV_EV,
+                            X86ModRM::MOD_01_DISP_RBP,
+                            target_x86reg,
+                            mc,
+                        );
+                        gen_size += Self::tcg_out(gpr_relat_address, 1, mc);
                     } else {
-                        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, target_x86reg, mc);
+                        gen_size += Self::tcg_modrm_64bit_out(
+                            X86Opcode::MOV_GV_EV,
+                            X86ModRM::MOD_10_DISP_RBP,
+                            target_x86reg,
+                            mc,
+                        );
                         gen_size += Self::tcg_out(gpr_relat_address, 4, mc);
                     }
                 }
             } else {
                 let gpr_relat_address = emu.calc_gpr_relat_address(src_reg.value) as u64;
                 if gpr_relat_address < 128 {
-                    gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_01_DISP_RBP, target_x86reg, mc);
+                    gen_size += Self::tcg_modrm_64bit_out(
+                        X86Opcode::MOV_GV_EV,
+                        X86ModRM::MOD_01_DISP_RBP,
+                        target_x86reg,
+                        mc,
+                    );
                     gen_size += Self::tcg_out(gpr_relat_address, 1, mc);
                 } else {
-                    gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, target_x86reg, mc);
+                    gen_size += Self::tcg_modrm_64bit_out(
+                        X86Opcode::MOV_GV_EV,
+                        X86ModRM::MOD_10_DISP_RBP,
+                        target_x86reg,
+                        mc,
+                    );
                     gen_size += Self::tcg_out(gpr_relat_address, 4, mc);
                 }
-            }    
+            }
             emu.m_gpr_usage_list[src_reg.value as usize] = Some(target_x86reg);
             emu.m_x86reg_usage_list[target_x86reg as usize] = Some(src_reg.value);
         } else {
             let gpr_relat_address = emu.calc_gpr_relat_address(src_reg.value) as u64;
-            gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, target_x86reg, mc);
+            gen_size += Self::tcg_modrm_64bit_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_10_DISP_RBP,
+                target_x86reg,
+                mc,
+            );
             gen_size += Self::tcg_out(gpr_relat_address, 4, mc);
         }
 
         return gen_size;
     }
 
-    fn tcg_gen_set_gpr(emu: &mut EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_set_gpr(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src_tmp = tcg.arg1.unwrap();
 
@@ -925,10 +1273,20 @@ impl TCG for TCGX86 {
         let mut gen_size = pc_address as usize;
         let gpr_relat_diff = emu.calc_gpr_relat_address(dest_reg.value) as u64;
         if gpr_relat_diff < 128 {
-            gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_01_DISP_RBP, source_x86reg, mc);
+            gen_size += Self::tcg_modrm_64bit_out(
+                X86Opcode::MOV_EV_GV,
+                X86ModRM::MOD_01_DISP_RBP,
+                source_x86reg,
+                mc,
+            );
             gen_size += Self::tcg_out(gpr_relat_diff, 1, mc);
         } else {
-            gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_10_DISP_RBP, source_x86reg, mc);
+            gen_size += Self::tcg_modrm_64bit_out(
+                X86Opcode::MOV_EV_GV,
+                X86ModRM::MOD_10_DISP_RBP,
+                source_x86reg,
+                mc,
+            );
             gen_size += Self::tcg_out(gpr_relat_diff, 4, mc);
         }
         emu.m_gpr_usage_list[dest_reg.value as usize] = Some(source_x86reg);
@@ -937,8 +1295,12 @@ impl TCG for TCGX86 {
         return gen_size;
     }
 
-
-    fn tcg_gen_move_stack(_emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_move_stack(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
 
         assert_eq!(dest_reg.t, TCGvType::TCGTemp);
@@ -946,12 +1308,22 @@ impl TCG for TCGX86 {
         let target_x86reg = Self::convert_x86_reg(dest_reg.value);
 
         let mut gen_size = pc_address as usize;
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RBP, target_x86reg, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RBP,
+            target_x86reg,
+            mc,
+        );
         return gen_size;
     }
 
-
-    fn tcg_gen_mem_load(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType) -> usize {
+    fn tcg_gen_mem_load(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+    ) -> usize {
         emu.m_x86reg_usage_list = [None; X86TargetRM::SENTINEL as usize];
         emu.m_gpr_usage_list = [None; 32];
 
@@ -968,48 +1340,94 @@ impl TCG for TCGX86 {
         gen_size += match mem_size {
             MemOpType::LOAD_64BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_64bit_raw_out(
+                    X86Opcode::MOV_GV_EV,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_32BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV_32BIT, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_64bit_raw_out(
+                    X86Opcode::MOV_GV_EV_32BIT,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_16BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_64bit_raw_out(X86Opcode::MOV_GV_EV_S_16BIT, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_2byte_64bit_raw_out(
+                    X86Opcode::MOV_GV_EV_S_16BIT,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_8BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_64bit_raw_out(X86Opcode::MOV_GV_EV_S_8BIT, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_2byte_64bit_raw_out(
+                    X86Opcode::MOV_GV_EV_S_8BIT,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_U_32BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_32bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_32bit_raw_out(
+                    X86Opcode::MOV_GV_EV,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_U_16BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_32bit_raw_out(X86Opcode::MOV_GV_EV_U_16BIT, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_2byte_32bit_raw_out(
+                    X86Opcode::MOV_GV_EV_U_16BIT,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_U_8BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_32bit_raw_out(X86Opcode::MOV_GV_EV_U_8BIT, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_2byte_32bit_raw_out(
+                    X86Opcode::MOV_GV_EV_U_8BIT,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             _ => panic!("Not supported load instruction."),
         };
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, target_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8,
+            target_x86reg as u8,
+            mc,
+        );
 
         return gen_size;
     }
 
-    fn tcg_gen_mem_store(emu: &mut EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType) -> usize {
+    fn tcg_gen_mem_store(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+    ) -> usize {
         emu.m_x86reg_usage_list = [None; X86TargetRM::SENTINEL as usize];
         emu.m_gpr_usage_list = [None; 32];
 
@@ -1022,28 +1440,52 @@ impl TCG for TCGX86 {
         let target_x86reg = Self::convert_x86_reg(dest_reg.value);
         let source_x86reg = Self::convert_x86_reg(src_reg.value);
 
-
         let mut gen_size = pc_address as usize;
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
         gen_size += match mem_size {
             MemOpType::STORE_64BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_64bit_raw_out(
+                    X86Opcode::MOV_EV_GV,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::STORE_32BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_32bit_raw_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_32bit_raw_out(
+                    X86Opcode::MOV_EV_GV,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::STORE_16BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_16bit_raw_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_16bit_raw_out(
+                    X86Opcode::MOV_EV_GV,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::STORE_8BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_32bit_raw_out(X86Opcode::MOV_EB_GB, X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8, X86TargetRM::RAX as u8, mc);
+                gen_size += Self::tcg_modrm_32bit_raw_out(
+                    X86Opcode::MOV_EB_GB,
+                    X86ModRM::MOD_00_DISP_RAX as u8 + source_x86reg as u8,
+                    X86TargetRM::RAX as u8,
+                    mc,
+                );
                 gen_size
             }
             _ => panic!("Unsupported memory size!"),
@@ -1051,7 +1493,12 @@ impl TCG for TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_tlbidx_offset(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_tlbidx_offset(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src_reg = tcg.arg1.unwrap();
 
@@ -1064,15 +1511,29 @@ impl TCG for TCGX86 {
         let mut gen_size = pc_address as usize;
 
         if dest_reg.value != src_reg.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source_x86reg as u8, target_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + source_x86reg as u8,
+                target_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::ADD_GV_IMM, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, 0, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::ADD_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+            0,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_tlb_relat_address() as u64, 4, mc);
         return gen_size;
     }
 
-
-    fn tcg_gen_tlbaddr_offset(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_tlbaddr_offset(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src_reg = tcg.arg1.unwrap();
 
@@ -1085,9 +1546,19 @@ impl TCG for TCGX86 {
         let mut gen_size = pc_address as usize;
 
         if dest_reg.value != src_reg.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + source_x86reg as u8, target_x86reg as u8, mc);    
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + source_x86reg as u8,
+                target_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::ADD_GV_IMM, X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8, 0, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::ADD_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX as u8 + target_x86reg as u8,
+            0,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_tlb_addr_relat_address() as u64, 4, mc);
         return gen_size;
     }
@@ -1106,15 +1577,29 @@ impl TCG for TCGX86 {
         let guestcode_addr = emu.calc_guest_data_mem_address();
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, guestcode_addr as u64, mc);
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, target_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8,
+            target_x86reg as u8,
+            mc,
+        );
         if dest_reg.value != offset.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + offset_x86reg as u8, target_x86reg as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::ADD_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + offset_x86reg as u8,
+                target_x86reg as u8,
+                mc,
+            );
         }
         return gen_size;
     }
 
-
-    fn tcg_gen_add_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_add_64bit(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         if tcg.arg2.unwrap().t == TCGvType::Immediate {
             Self::tcg_gen_op_temp_imm(emu, pc_address, X86Opcode::ADD_GV_IMM, tcg, mc)
         } else {
@@ -1139,7 +1624,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_sub_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_sub_64bit(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         if tcg.arg2.unwrap().t == TCGvType::Immediate {
             Self::tcg_gen_op_temp_imm(emu, pc_address, X86Opcode::SUB_GV_IMM, tcg, mc)
         } else {
@@ -1147,7 +1637,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_and_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_and_64bit(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         if tcg.arg2.unwrap().t == TCGvType::Immediate {
             Self::tcg_gen_op_temp_imm(emu, pc_address, X86Opcode::AND_GV_IMM, tcg, mc)
         } else {
@@ -1163,7 +1658,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_xor_64bit(emu: &mut EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_xor_64bit(
+        emu: &mut EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         if tcg.arg2.unwrap().t == TCGvType::Immediate {
             Self::tcg_gen_op_temp_imm(emu, pc_address, X86Opcode::XOR_GV_IMM, tcg, mc)
         } else {
@@ -1171,7 +1671,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_mul_64bit(_emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_mul_64bit(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest = tcg.arg0.unwrap();
         let src1 = tcg.arg1.unwrap();
         let src2 = tcg.arg2.unwrap();
@@ -1187,14 +1692,29 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         if dest.value != src1.value {
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, dest_x86reg as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+                dest_x86reg as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_2byte_64bit_raw_out(X86Opcode::IMUL_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, dest_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_2byte_64bit_raw_out(
+            X86Opcode::IMUL_RDX_RAX_R,
+            X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+            dest_x86reg as u8,
+            mc,
+        );
 
         gen_size
     }
 
-    fn tcg_gen_div_64bit(_emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_div_64bit(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest = tcg.arg0.unwrap();
         let src1 = tcg.arg1.unwrap();
         let src2 = tcg.arg2.unwrap();
@@ -1209,23 +1729,53 @@ impl TCG for TCGX86 {
 
         let mut gen_size: usize = pc_address as usize;
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
         if src2_x86reg == X86TargetRM::RDX {
             // swap src1 into src2
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, src1_x86reg as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                src1_x86reg as u8,
+                mc,
+            );
             gen_size += Self::tcg_64bit_out(X86Opcode::CQO, mc);
             // use src1_x86reg instead of src1
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::IDIV_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::IDIV_RDX_RAX_R,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
         } else {
             gen_size += Self::tcg_64bit_out(X86Opcode::CQO, mc);
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::IDIV_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, X86TargetRM::RAX as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::IDIV_RDX_RAX_R,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
         }
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, dest_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8,
+            dest_x86reg as u8,
+            mc,
+        );
 
         gen_size
     }
 
-    fn tcg_gen_divu_64bit(_emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_divu_64bit(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest = tcg.arg0.unwrap();
         let src1 = tcg.arg1.unwrap();
         let src2 = tcg.arg2.unwrap();
@@ -1240,26 +1790,54 @@ impl TCG for TCGX86 {
 
         let mut gen_size: usize = pc_address as usize;
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
         if src2_x86reg == X86TargetRM::RDX {
             // swap src1 into src2
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, src1_x86reg as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                src1_x86reg as u8,
+                mc,
+            );
             gen_size += Self::tcg_64bit_out(X86Opcode::CQO, mc);
             // use src1_x86reg instead of src1
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::DIV_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::DIV_RDX_RAX_R,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
         } else {
             gen_size += Self::tcg_64bit_out(X86Opcode::CQO, mc);
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::DIV_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, X86TargetRM::RAX as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::DIV_RDX_RAX_R,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
         }
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8, dest_x86reg as u8, mc);
-
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8,
+            dest_x86reg as u8,
+            mc,
+        );
 
         gen_size
     }
 
-
-    fn tcg_gen_rem_64bit(_emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_rem_64bit(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest = tcg.arg0.unwrap();
         let src1 = tcg.arg1.unwrap();
         let src2 = tcg.arg2.unwrap();
@@ -1274,24 +1852,54 @@ impl TCG for TCGX86 {
 
         let mut gen_size: usize = pc_address as usize;
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
         if src2_x86reg == X86TargetRM::RDX {
             // swap src1 into src2
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, src1_x86reg as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::MOV_GV_EV,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                src1_x86reg as u8,
+                mc,
+            );
             gen_size += Self::tcg_64bit_out(X86Opcode::CQO, mc);
             // use src1_x86reg instead of src1
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::DIV_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::DIV_RDX_RAX_R,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
         } else {
             gen_size += Self::tcg_64bit_out(X86Opcode::CQO, mc);
-            gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::DIV_RDX_RAX_R, X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8, X86TargetRM::RAX as u8, mc);
+            gen_size += Self::tcg_modrm_64bit_raw_out(
+                X86Opcode::DIV_RDX_RAX_R,
+                X86ModRM::MOD_11_DISP_RAX as u8 + src2_x86reg as u8,
+                X86TargetRM::RAX as u8,
+                mc,
+            );
         }
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RDX as u8, dest_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX as u8,
+            dest_x86reg as u8,
+            mc,
+        );
 
         gen_size
     }
 
-    fn tcg_gen_sign_ext_32_64(_emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_sign_ext_32_64(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let source1_reg = tcg.arg1.unwrap();
 
@@ -1303,13 +1911,22 @@ impl TCG for TCGX86 {
         let dest_x86reg = Self::convert_x86_reg(dest_reg.value);
         let source1_x86reg = Self::convert_x86_reg(source1_reg.value);
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV_32BIT, X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8, 
-                dest_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV_32BIT,
+            X86ModRM::MOD_11_DISP_RAX as u8 + source1_x86reg as u8,
+            dest_x86reg as u8,
+            mc,
+        );
 
         gen_size
     }
 
-    fn tcg_gen_srl_64bit(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_srl_64bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let arg0 = tcg.arg0.unwrap();
         let arg1 = tcg.arg1.unwrap();
         let arg2 = tcg.arg2.unwrap();
@@ -1328,7 +1945,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_sll_64bit(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_sll_64bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let arg0 = tcg.arg0.unwrap();
         let arg1 = tcg.arg1.unwrap();
         let arg2 = tcg.arg2.unwrap();
@@ -1347,7 +1969,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_sra_64bit(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_sra_64bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let arg0 = tcg.arg0.unwrap();
         let arg1 = tcg.arg1.unwrap();
         let arg2 = tcg.arg2.unwrap();
@@ -1381,11 +2008,21 @@ impl TCG for TCGX86 {
 
         let src1_x86reg = Self::convert_x86_reg(src1.value);
 
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, X86TargetRM::RAX as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+            X86TargetRM::RAX as u8,
+            mc,
+        );
         gen_size += Self::tcg_64bit_out(X86Opcode::ADD_EAX_IV, mc);
         gen_size += Self::tcg_out(src2.value as u64, 4, mc);
         // RAX --> PC
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_EV_GV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_pc_address() as u64, 4, mc); // Set Program Counter
 
         return gen_size;
@@ -1514,7 +2151,12 @@ impl TCG for TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_mov_imm_64bit(_emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_mov_imm_64bit(
+        _emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let op = tcg.op.unwrap();
         let dest = tcg.arg0.unwrap();
         let imm = tcg.arg1.unwrap();
@@ -1531,7 +2173,6 @@ impl TCG for TCGX86 {
 
         return gen_size;
     }
-
 
     fn tcg_out_reloc(host_code_ptr: usize, label: &Rc<RefCell<TCGLabel>>) -> usize {
         // let mut l = &mut *label.borrow_mut();
@@ -1557,7 +2198,14 @@ impl TCG for TCGX86 {
     }
 
     /* Memory Access : Load */
-    fn tcg_gen_load(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType, target_reg: RegisterType) -> usize {
+    fn tcg_gen_load(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+        target_reg: RegisterType,
+    ) -> usize {
         let mut gen_size: usize = pc_address as usize;
 
         let arg0 = tcg.arg0.unwrap();
@@ -1571,58 +2219,133 @@ impl TCG for TCGX86 {
         // Load Guest Memory Head into EAX
         let guestcode_addr = emu.calc_guest_data_mem_address();
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, guestcode_addr as u64, mc);
-        
+
         // Move Guest Memory from EAX to ECX
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RCX, mc);
-        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RCX,
+            mc,
+        );
+
         // Load value from rs1
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_gpr_relat_address(arg1.value) as u64, 4, mc);
-        
+
         // rs1 + imm
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_IMM /* ADD_EV_IV */, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_IMM, /* ADD_EV_IV */
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(arg2.value as u64, 4, mc);
 
         // Move RDX --> RSI (Base Address)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RSI, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RSI,
+            mc,
+        );
 
         // Extract lower 12-bit to search TLB table offset (RSI)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_IMM, X86ModRM::MOD_11_DISP_RSI, X86TargetRM::SIB, mc);
-        gen_size += Self::tcg_out(0x0fff, 4, mc);        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_IMM,
+            X86ModRM::MOD_11_DISP_RSI,
+            X86TargetRM::SIB,
+            mc,
+        );
+        gen_size += Self::tcg_out(0x0fff, 4, mc);
 
         // Shift right 12-bit to search TLB table (RCX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SRL_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SRL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(12, 1, mc);
 
         // Extract lower 12-bit to search TLB table offset (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(0x0fff, 4, mc);
 
         // Right shift 3 bit to align 64-bit entry size (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SLL_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SLL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(3, 1, mc);
 
         // Move RAX --> RDX (Extracted Address Offset)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RDX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RDX,
+            mc,
+        );
 
         // Move RBP --> RAX (Base Address)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RBP, X86TargetRM::RAX, mc);
-        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Load TLB Vector Address Base Address
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_IMM /* ADD_EV_IV */, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_IMM, /* ADD_EV_IV */
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_tlb_addr_relat_address() as u64, 4, mc);
 
         // Add TLB base address offset (RAX)
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
         // Load Physical Address from TLB address table
-        Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_00_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
         // Physical Address + 12bit offset in RSI
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RSI, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RSI,
+            X86TargetRM::RAX,
+            mc,
+        );
 
         // Physical Address + Memory Head Address
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
         // Address Calculation : Sub Bias 0x8000_0000
         gen_size += Self::tcg_64bit_out(X86Opcode::ADD_EAX_IV, mc);
@@ -1631,37 +2354,72 @@ impl TCG for TCGX86 {
         gen_size += match mem_size {
             MemOpType::LOAD_64BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_64bit_out(
+                    X86Opcode::MOV_GV_EV,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_32BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV_32BIT, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_64bit_out(
+                    X86Opcode::MOV_GV_EV_32BIT,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_16BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_64bit_out(X86Opcode::MOV_GV_EV_S_16BIT, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_2byte_64bit_out(
+                    X86Opcode::MOV_GV_EV_S_16BIT,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_8BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_64bit_out(X86Opcode::MOV_GV_EV_S_8BIT, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_2byte_64bit_out(
+                    X86Opcode::MOV_GV_EV_S_8BIT,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_U_32BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_32bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_32bit_out(
+                    X86Opcode::MOV_GV_EV,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_U_16BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_32bit_out(X86Opcode::MOV_GV_EV_U_16BIT, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_2byte_32bit_out(
+                    X86Opcode::MOV_GV_EV_U_16BIT,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::LOAD_U_8BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_2byte_32bit_out(X86Opcode::MOV_GV_EV_U_8BIT, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
+                gen_size += Self::tcg_modrm_2byte_32bit_out(
+                    X86Opcode::MOV_GV_EV_U_8BIT,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RAX,
+                    mc,
+                );
                 gen_size
             }
             _ => panic!("Not supported load instruction."),
@@ -1681,7 +2439,14 @@ impl TCG for TCGX86 {
     }
 
     /* Memory Access : Store */
-    fn tcg_gen_store(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>, mem_size: MemOpType, target_reg: RegisterType) -> usize {
+    fn tcg_gen_store(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &TCGOp,
+        mc: &mut Vec<u8>,
+        mem_size: MemOpType,
+        target_reg: RegisterType,
+    ) -> usize {
         let mut gen_size: usize = pc_address as usize;
 
         let rs1 = tcg.arg0.unwrap();
@@ -1695,63 +2460,138 @@ impl TCG for TCGX86 {
         // Load Guest Memory Head into EAX
         let guestcode_addr = emu.calc_guest_data_mem_address();
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, guestcode_addr as u64, mc);
-        
+
         // Move Guest Memory from EAX to ECX
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RCX, mc);
-        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RCX,
+            mc,
+        );
+
         // Load value from rs1
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_gpr_relat_address(rs1.value) as u64, 4, mc);
-        
+
         // rs1 + imm
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_IMM /* ADD_EV_IV */, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_IMM, /* ADD_EV_IV */
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(imm.value as u64, 4, mc);
-    
+
         // Move RDX --> RSI (Base Address)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RSI, mc);
-    
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RSI,
+            mc,
+        );
+
         // Extract lower 12-bit to search TLB table offset (RSI)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_IMM, X86ModRM::MOD_11_DISP_RSI, X86TargetRM::SIB, mc);
-        gen_size += Self::tcg_out(0x0fff, 4, mc);        
-    
-        // Shift right 12-bit to search TLB table (RCX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SRL_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
-        gen_size += Self::tcg_out(12, 1, mc);
-    
-        // Extract lower 12-bit to search TLB table offset (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_IMM,
+            X86ModRM::MOD_11_DISP_RSI,
+            X86TargetRM::SIB,
+            mc,
+        );
         gen_size += Self::tcg_out(0x0fff, 4, mc);
-    
+
+        // Shift right 12-bit to search TLB table (RCX)
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SRL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
+        gen_size += Self::tcg_out(12, 1, mc);
+
+        // Extract lower 12-bit to search TLB table offset (RAX)
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
+        gen_size += Self::tcg_out(0x0fff, 4, mc);
+
         // Right shift 3 bit to align 64-bit entry size (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SLL_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SLL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(3, 1, mc);
-    
+
         // Move RAX --> RDX (Extracted Address Offset)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RDX, mc);
-    
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RDX,
+            mc,
+        );
+
         // Move RBP --> RAX (Base Address)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RBP, X86TargetRM::RAX, mc);
-        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Load TLB Vector Address Base Address
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_IMM /* ADD_EV_IV */, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_IMM, /* ADD_EV_IV */
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_tlb_addr_relat_address() as u64, 4, mc);
-    
+
         // Add TLB base address offset (RAX)
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
-    
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Load Physical Address from TLB address table
-        Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RAX, mc);
-    
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_00_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Physical Address + 12bit offset in RSI
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RSI, X86TargetRM::RAX, mc);
-    
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RSI,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Physical Address + Memory Head Address
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
-    
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Address Calculation : Sub Bias 0x8000_0000
         gen_size += Self::tcg_64bit_out(X86Opcode::ADD_EAX_IV, mc);
-        gen_size += Self::tcg_out(0x8000_0000 as u64, 4, mc);        
-        
+        gen_size += Self::tcg_out(0x8000_0000 as u64, 4, mc);
+
         // Load value from rs2 (data)
         if target_reg == RegisterType::IntRegister {
             gen_size += Self::tcg_gen_load_gpr_64bit(emu, X86TargetRM::RCX, rs2.value, mc);
@@ -1765,22 +2605,42 @@ impl TCG for TCGX86 {
         gen_size += match mem_size {
             MemOpType::STORE_64BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RCX, mc);
+                gen_size += Self::tcg_modrm_64bit_out(
+                    X86Opcode::MOV_EV_GV,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RCX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::STORE_32BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_32bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RCX, mc);
+                gen_size += Self::tcg_modrm_32bit_out(
+                    X86Opcode::MOV_EV_GV,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RCX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::STORE_16BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_16bit_out(X86Opcode::MOV_EV_GV, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RCX, mc);
+                gen_size += Self::tcg_modrm_16bit_out(
+                    X86Opcode::MOV_EV_GV,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RCX,
+                    mc,
+                );
                 gen_size
             }
             MemOpType::STORE_8BIT => {
                 let mut gen_size = 0;
-                gen_size += Self::tcg_modrm_32bit_out(X86Opcode::MOV_EB_GB, X86ModRM::MOD_00_DISP_RAX, X86TargetRM::RCX, mc);
+                gen_size += Self::tcg_modrm_32bit_out(
+                    X86Opcode::MOV_EB_GB,
+                    X86ModRM::MOD_00_DISP_RAX,
+                    X86TargetRM::RCX,
+                    mc,
+                );
                 gen_size
             }
             _ => panic!("Unsupported memory size!"),
@@ -1960,7 +2820,12 @@ impl TCG for TCGX86 {
         return gen_size;
     }
 
-    fn tcg_gen_srl_32bit(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_srl_32bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_reg = tcg.arg0.unwrap();
         let src1_reg = tcg.arg1.unwrap();
         let src2_reg = tcg.arg2.unwrap();
@@ -1979,7 +2844,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_sll_32bit(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_sll_32bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let dest_temp = tcg.arg0.unwrap();
         let src1_temp = tcg.arg1.unwrap();
         let src2_temp = tcg.arg2.unwrap();
@@ -1998,7 +2868,12 @@ impl TCG for TCGX86 {
         }
     }
 
-    fn tcg_gen_sra_32bit(emu: &EmuEnv, pc_address: u64, tcg: &tcg::TCGOp, mc: &mut Vec<u8>) -> usize {
+    fn tcg_gen_sra_32bit(
+        emu: &EmuEnv,
+        pc_address: u64,
+        tcg: &tcg::TCGOp,
+        mc: &mut Vec<u8>,
+    ) -> usize {
         let arg0 = tcg.arg0.unwrap();
         let arg1 = tcg.arg1.unwrap();
         let arg2 = tcg.arg2.unwrap();
@@ -2097,7 +2972,6 @@ impl TCG for TCGX86 {
         return gen_size;
     }
 
-
     fn tcg_gen_sgnj_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
         let op = tcg.op.unwrap();
         let arg0 = tcg.arg0.unwrap();
@@ -2112,14 +2986,29 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0x7fffffff_ffffffff, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg1.value) as u64, 4, mc);
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0x80000000_00000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg2.value) as u64, 4, mc);
 
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_gen_store_fregs_64bit(emu, X86TargetRM::RAX, arg0.value, mc);
 
         return gen_size;
@@ -2139,20 +3028,39 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0x7fffffff_ffffffff, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg1.value) as u64, 4, mc);
 
         gen_size += Self::tcg_gen_load_fregs_64bit(emu, X86TargetRM::RDX, arg2.value, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::NEG_GV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RDX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::NEG_GV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RDX,
+            mc,
+        );
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0x80000000_00000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_gen_store_fregs_64bit(emu, X86TargetRM::RAX, arg0.value, mc);
 
         return gen_size;
     }
-
 
     fn tcg_gen_sgnjx_64bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
         let op = tcg.op.unwrap();
@@ -2168,16 +3076,36 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0x7fffffff_ffffffff, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg1.value) as u64, 4, mc);
 
         gen_size += Self::tcg_gen_load_fregs_64bit(emu, X86TargetRM::RDX, arg1.value, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::XOR_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RDX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::XOR_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RDX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg2.value) as u64, 4, mc);
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0x80000000_00000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_gen_store_fregs_64bit(emu, X86TargetRM::RAX, arg0.value, mc);
 
         return gen_size;
@@ -2197,14 +3125,29 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0x7fffffff, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg1.value) as u64, 4, mc);
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0x80000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg2.value) as u64, 4, mc);
 
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_gen_store_fregs_32bit(emu, X86TargetRM::RAX, arg0.value, mc);
 
         return gen_size;
@@ -2224,20 +3167,39 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0x7fffffff, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg1.value) as u64, 4, mc);
 
         gen_size += Self::tcg_gen_load_fregs_64bit(emu, X86TargetRM::RDX, arg2.value, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::NEG_GV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RDX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::NEG_GV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RDX,
+            mc,
+        );
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0x80000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_gen_store_fregs_32bit(emu, X86TargetRM::RAX, arg0.value, mc);
 
         return gen_size;
     }
-
 
     fn tcg_gen_sgnjx_32bit(emu: &EmuEnv, pc_address: u64, tcg: &TCGOp, mc: &mut Vec<u8>) -> usize {
         let op = tcg.op.unwrap();
@@ -2253,16 +3215,36 @@ impl TCG for TCGX86 {
         let mut gen_size: usize = pc_address as usize;
 
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RCX, 0x7fffffff, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg1.value) as u64, 4, mc);
 
         gen_size += Self::tcg_gen_load_fregs_64bit(emu, X86TargetRM::RDX, arg1.value, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::XOR_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RDX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::XOR_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RDX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_fregs_relat_address(arg2.value) as u64, 4, mc);
         gen_size += Self::tcg_gen_imm_u64(X86TargetRM::RAX, 0x80000000, mc);
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::OR_GV_EV, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::OR_GV_EV,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_gen_store_fregs_32bit(emu, X86TargetRM::RAX, arg0.value, mc);
 
         return gen_size;
@@ -2285,7 +3267,12 @@ impl TCG for TCGX86 {
         let src2_x86reg = Self::convert_x86_reg(src2.value);
 
         // Compare Offset Table and address upper bit
-        gen_size += Self::tcg_modrm_64bit_raw_out(X86Opcode::CMP_GV_EV, X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8, src2_x86reg as u8, mc);
+        gen_size += Self::tcg_modrm_64bit_raw_out(
+            X86Opcode::CMP_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX as u8 + src1_x86reg as u8,
+            src2_x86reg as u8,
+            mc,
+        );
 
         gen_size += Self::tcg_out(X86Opcode::JE_rel16_32 as u64, 2, mc);
         // gen_size += Self::tcg_out(0x4a as u64, 4, mc);
@@ -2305,48 +3292,107 @@ impl TCG for TCGX86 {
         assert_eq!(addr_imm.t, TCGvType::Immediate);
 
         // Load value from rs1
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_10_DISP_RBP, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_10_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_gpr_relat_address(base_addr.value) as u64, 4, mc);
         // rs1 + imm
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_IMM /* ADD_EV_IV */, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_IMM, /* ADD_EV_IV */
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(addr_imm.value as u64, 4, mc);
 
         // Move RAX --> RCX
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RCX,
+            mc,
+        );
 
         // Shift right 12-bit to search TLB table (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SRL_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SRL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(12, 1, mc);
-        
 
         // Shift right 12-bit to search TLB table (RCX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SRL_GV_IMM, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SRL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(12, 1, mc);
 
         // Extract lower 12-bit to search TLB table offset (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::AND_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::AND_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(0x0fff, 4, mc);
 
         // Right shift 3 bit to align 64-bit entry size (RAX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SLL_GV_IMM, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SLL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(3, 1, mc);
-        
+
         // Move RAX --> RDX (Extracted Address Offset)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RDX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RDX,
+            mc,
+        );
 
         // Move RBP --> RAX (Base Address)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::MOV_GV_EV, X86ModRM::MOD_11_DISP_RBP, X86TargetRM::RAX, mc);
-        
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::MOV_GV_EV,
+            X86ModRM::MOD_11_DISP_RBP,
+            X86TargetRM::RAX,
+            mc,
+        );
+
         // Shift right more 12-bit to search TLB table (RCX)
-        gen_size += Self::tcg_modrm_64bit_out(X86Opcode::SRL_GV_IMM, X86ModRM::MOD_11_DISP_RCX, X86TargetRM::RCX, mc);
+        gen_size += Self::tcg_modrm_64bit_out(
+            X86Opcode::SRL_GV_IMM,
+            X86ModRM::MOD_11_DISP_RCX,
+            X86TargetRM::RCX,
+            mc,
+        );
         gen_size += Self::tcg_out(12, 1, mc);
-        
+
         // Load TLB Vector Base Address
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_IMM /* ADD_EV_IV */, X86ModRM::MOD_11_DISP_RAX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_IMM, /* ADD_EV_IV */
+            X86ModRM::MOD_11_DISP_RAX,
+            X86TargetRM::RAX,
+            mc,
+        );
         gen_size += Self::tcg_out(emu.calc_tlb_relat_address() as u64, 4, mc);
 
         // Add TLB base address offset (RAX)
-        Self::tcg_modrm_64bit_out(X86Opcode::ADD_GV_EV, X86ModRM::MOD_11_DISP_RDX, X86TargetRM::RAX, mc);
+        Self::tcg_modrm_64bit_out(
+            X86Opcode::ADD_GV_EV,
+            X86ModRM::MOD_11_DISP_RDX,
+            X86TargetRM::RAX,
+            mc,
+        );
 
         return gen_size;
     }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,184 +1,1387 @@
 extern crate dydra;
 
+#[test]
+fn rv64ui_p_simple() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-simple".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_simple  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-simple".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_add() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_addi() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addi".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_addiw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addiw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_addw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sub() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sub".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_subw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-subw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_add     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add".to_string(), false),  1); }
-#[test]fn rv64ui_p_addi    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addi".to_string(), false),  1); }
-#[test]fn rv64ui_p_addiw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addiw".to_string(), false),  1); }
-#[test]fn rv64ui_p_addw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addw".to_string(), false),  1); }
-#[test]fn rv64ui_p_sub     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sub".to_string(), false),  1); }
-#[test]fn rv64ui_p_subw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-subw".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_and() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-and".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_andi() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-andi".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_or() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-or".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_ori() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ori".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_xor() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xor".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_xori() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xori".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_and     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-and".to_string(), false),  1); }
-#[test]fn rv64ui_p_andi    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-andi".to_string(), false),  1); }
-#[test]fn rv64ui_p_or      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-or".to_string(), false),  1); }
-#[test]fn rv64ui_p_ori     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ori".to_string(), false),  1); }
-#[test]fn rv64ui_p_xor     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xor".to_string(), false),  1); }
-#[test]fn rv64ui_p_xori    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xori".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_auipc() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-auipc".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lui() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lui".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_auipc   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-auipc".to_string(), false),  1); }
-#[test]fn rv64ui_p_lui     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lui".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_beq() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-beq".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bge() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bge".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bgeu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bgeu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_blt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-blt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bltu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bltu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bne() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bne".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_beq     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-beq".to_string(), false),  1); }
-#[test]fn rv64ui_p_bge     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bge".to_string(), false),  1); }
-#[test]fn rv64ui_p_bgeu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bgeu".to_string(), false),  1); }
-#[test]fn rv64ui_p_blt     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-blt".to_string(), false),  1); }
-#[test]fn rv64ui_p_bltu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bltu".to_string(), false),  1); }
-#[test]fn rv64ui_p_bne     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bne".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_fence_i() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-fence_i".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_fence_i () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-fence_i".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_jal() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jal".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_jalr() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jalr".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_jal     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jal".to_string(), false),  1); }
-#[test]fn rv64ui_p_jalr    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jalr".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_lb() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lb".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lbu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lbu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_ld() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ld".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lh() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lh".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lhu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lhu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lwu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lwu".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_lb      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lb".to_string(), false),  1); }
-#[test]fn rv64ui_p_lbu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lbu".to_string(), false),  1); }
-#[test]fn rv64ui_p_ld      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ld".to_string(), false),  1); }
-#[test]fn rv64ui_p_lh      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lh".to_string(), false),  1); }
-#[test]fn rv64ui_p_lhu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lhu".to_string(), false),  1); }
-#[test]fn rv64ui_p_lw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lw".to_string(), false),  1); }
-#[test]fn rv64ui_p_lwu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lwu".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_sb() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sb".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sh() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sh".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_sb      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sb".to_string(), false),  1); }
-#[test]fn rv64ui_p_sd      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sd".to_string(), false),  1); }
-#[test]fn rv64ui_p_sh      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sh".to_string(), false),  1); }
-#[test]fn rv64ui_p_sw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sw".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_slt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_slti() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slti".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sltiu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltiu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sltu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltu".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_slt     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slt".to_string(), false),  1); }
-#[test]fn rv64ui_p_slti    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slti".to_string(), false),  1); }
-#[test]fn rv64ui_p_sltiu   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltiu".to_string(), false),  1); }
-#[test]fn rv64ui_p_sltu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltu".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_sll() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sll".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_slli() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slli".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_slliw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slliw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sllw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sllw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_sll     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sll".to_string(), false),  1); }
-#[test]fn rv64ui_p_slli    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slli".to_string(), false),  1); }
-#[test]fn rv64ui_p_slliw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slliw".to_string(), false),  1); }
-#[test]fn rv64ui_p_sllw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sllw".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_sra() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sra".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srai() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srai".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sraiw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraiw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sraw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_sra     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sra".to_string(), false),  1); }
-#[test]fn rv64ui_p_srai    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srai".to_string(), false),  1); }
-#[test]fn rv64ui_p_sraiw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraiw".to_string(), false),  1); }
-#[test]fn rv64ui_p_sraw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraw".to_string(), false),  1); }
+#[test]
+fn rv64ui_p_srl() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srl".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srli() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srli".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srliw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srliw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srlw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srlw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_srl     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srl".to_string(), false),  1); }
-#[test]fn rv64ui_p_srli    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srli".to_string(), false),  1); }
-#[test]fn rv64ui_p_srliw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srliw".to_string(), false),  1); }
-#[test]fn rv64ui_p_srlw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srlw".to_string(), false),  1); }
-
-#[test]fn rv64ud_p_fadd      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fadd".to_string(), false),  1); }
-#[test]fn rv64ud_p_fclass    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fclass".to_string(), false),  1); }
-#[test]fn rv64ud_p_fcmp      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcmp".to_string(), false),  1); }
-#[test]fn rv64ud_p_fcvt      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt".to_string(), false),  1); }
-#[test]fn rv64ud_p_fcvt_w    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt_w".to_string(), false),  1); }
-#[test]fn rv64ud_p_fdiv      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fdiv".to_string(), false),  1); }
-#[test]fn rv64ud_p_fmadd     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmadd".to_string(), false),  1); }
-#[test]fn rv64ud_p_fmin      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmin".to_string(), false),  1); }
+#[test]
+fn rv64ud_p_fadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fclass() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fclass".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fcmp() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcmp".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fcvt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fcvt_w() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt_w".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fdiv() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fdiv".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fmadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fmin() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmin".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64ud_p_ldst      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-ldst".to_string(), false),  1); }
 // #[test]fn rv64ud_p_move      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-move".to_string(), false),  1); }
 // #[test]fn rv64ud_p_recoding  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-recoding".to_string(), false),  1); }
 // #[test]fn rv64ud_p_structural() { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-structural".to_string(), false),  1); }
 
-#[test]fn rv64uf_p_fadd      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fadd".to_string(), false),  1); }
-#[test]fn rv64uf_p_fclass    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fclass".to_string(), false),  1); }
-#[test]fn rv64uf_p_fcmp      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcmp".to_string(), false),  1); }
-#[test]fn rv64uf_p_fcvt      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt".to_string(), false),  1); }
-#[test]fn rv64uf_p_fcvt_w    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt_w".to_string(), false),  1); }
-#[test]fn rv64uf_p_fdiv      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fdiv".to_string(), false),  1); }
-#[test]fn rv64uf_p_fmadd     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmadd".to_string(), false),  1); }
-#[test]fn rv64uf_p_fmin      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmin".to_string(), false),  1); }
+#[test]
+fn rv64uf_p_fadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fclass() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fclass".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fcmp() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcmp".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fcvt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fcvt_w() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt_w".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fdiv() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fdiv".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fmadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fmin() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmin".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64uf_p_ldst      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-ldst".to_string(), false),  1); }
 // #[test]fn rv64uf_p_move      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-move".to_string(), false),  1); }
 // #[test]fn rv64uf_p_recoding  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-recoding".to_string(), false),  1); }
 // #[test]fn rv64uf_p_structural() { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-structural".to_string(), false),  1); }
 
-#[test]fn rv64ui_v_simple  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-simple".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_simple() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-simple".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_add     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-add".to_string(), false),  1); }
-#[test]fn rv64ui_v_addi    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addi".to_string(), false),  1); }
-#[test]fn rv64ui_v_addiw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addiw".to_string(), false),  1); }
-#[test]fn rv64ui_v_addw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addw".to_string(), false),  1); }
-#[test]fn rv64ui_v_sub     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sub".to_string(), false),  1); }
-#[test]fn rv64ui_v_subw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-subw".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_add() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-add".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_addi() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addi".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_addiw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addiw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_addw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sub() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sub".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_subw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-subw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_and     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-and".to_string(), false),  1); }
-#[test]fn rv64ui_v_andi    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-andi".to_string(), false),  1); }
-#[test]fn rv64ui_v_or      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-or".to_string(), false),  1); }
-#[test]fn rv64ui_v_ori     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ori".to_string(), false),  1); }
-#[test]fn rv64ui_v_xor     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xor".to_string(), false),  1); }
-#[test]fn rv64ui_v_xori    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xori".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_and() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-and".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_andi() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-andi".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_or() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-or".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_ori() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ori".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_xor() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xor".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_xori() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xori".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_auipc   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-auipc".to_string(), false),  1); }
-#[test]fn rv64ui_v_lui     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lui".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_auipc() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-auipc".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lui() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lui".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_beq     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-beq".to_string(), false),  1); }
-#[test]fn rv64ui_v_bge     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bge".to_string(), false),  1); }
-#[test]fn rv64ui_v_bgeu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bgeu".to_string(), false),  1); }
-#[test]fn rv64ui_v_blt     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-blt".to_string(), false),  1); }
-#[test]fn rv64ui_v_bltu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bltu".to_string(), false),  1); }
-#[test]fn rv64ui_v_bne     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bne".to_string(), false),  1); }
-#[test]fn rv64ui_v_fence_i () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-fence_i".to_string(), false),  1); }
-#[test]fn rv64ui_v_jal     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jal".to_string(), false),  1); }
-#[test]fn rv64ui_v_jalr    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jalr".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_beq() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-beq".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bge() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bge".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bgeu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bgeu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_blt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-blt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bltu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bltu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bne() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bne".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_fence_i() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-fence_i".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_jal() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jal".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_jalr() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jalr".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_lb      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lb".to_string(), false),  1); }
-#[test]fn rv64ui_v_lbu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lbu".to_string(), false),  1); }
-#[test]fn rv64ui_v_ld      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ld".to_string(), false),  1); }
-#[test]fn rv64ui_v_lh      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lh".to_string(), false),  1); }
-#[test]fn rv64ui_v_lhu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lhu".to_string(), false),  1); }
-#[test]fn rv64ui_v_lw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lw".to_string(), false),  1); }
-#[test]fn rv64ui_v_lwu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lwu".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_lb() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lb".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lbu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lbu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_ld() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ld".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lh() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lh".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lhu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lhu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lwu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lwu".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_sb      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sb".to_string(), false),  1); }
-#[test]fn rv64ui_v_sd      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sd".to_string(), false),  1); }
-#[test]fn rv64ui_v_sh      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sh".to_string(), false),  1); }
-#[test]fn rv64ui_v_sw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sw".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_sb() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sb".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sh() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sh".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_slt     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slt".to_string(), false),  1); }
-#[test]fn rv64ui_v_slti    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slti".to_string(), false),  1); }
-#[test]fn rv64ui_v_sltiu   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltiu".to_string(), false),  1); }
-#[test]fn rv64ui_v_sltu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltu".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_slt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_slti() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slti".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sltiu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltiu".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sltu() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltu".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_sll     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sll".to_string(), false),  1); }
-#[test]fn rv64ui_v_slli    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slli".to_string(), false),  1); }
-#[test]fn rv64ui_v_slliw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slliw".to_string(), false),  1); }
-#[test]fn rv64ui_v_sllw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sllw".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_sll() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sll".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_slli() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slli".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_slliw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slliw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sllw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sllw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_sra     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sra".to_string(), false),  1); }
-#[test]fn rv64ui_v_srai    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srai".to_string(), false),  1); }
-#[test]fn rv64ui_v_sraiw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraiw".to_string(), false),  1); }
-#[test]fn rv64ui_v_sraw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraw".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_sra() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sra".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srai() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srai".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sraiw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraiw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sraw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_srl     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srl".to_string(), false),  1); }
-#[test]fn rv64ui_v_srli    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srli".to_string(), false),  1); }
-#[test]fn rv64ui_v_srliw   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srliw".to_string(), false),  1); }
-#[test]fn rv64ui_v_srlw    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srlw".to_string(), false),  1); }
+#[test]
+fn rv64ui_v_srl() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srl".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srli() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srli".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srliw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srliw".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srlw() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srlw".to_string(),
+            false
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ud_v_fadd      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fadd".to_string(), false),  1); }
-#[test]fn rv64ud_v_fclass    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fclass".to_string(), false),  1); }
-#[test]fn rv64ud_v_fcmp      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcmp".to_string(), false),  1); }
-#[test]fn rv64ud_v_fcvt      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt".to_string(), false),  1); }
-#[test]fn rv64ud_v_fcvt_w    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt_w".to_string(), false),  1); }
-#[test]fn rv64ud_v_fdiv      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fdiv".to_string(), false),  1); }
-#[test]fn rv64ud_v_fmadd     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmadd".to_string(), false),  1); }
-#[test]fn rv64ud_v_fmin      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmin".to_string(), false),  1); }
+#[test]
+fn rv64ud_v_fadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fclass() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fclass".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fcmp() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcmp".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fcvt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fcvt_w() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt_w".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fdiv() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fdiv".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fmadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fmin() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmin".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64ud_v_ldst      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-ldst".to_string(), false),  1); }
 // #[test]fn rv64ud_v_move      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-move".to_string(), false),  1); }
 // #[test]fn rv64ud_v_recoding  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-recoding".to_string(), false),  1); }
 // #[test]fn rv64ud_v_structural() { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-structural".to_string(), false),  1); }
-#[test]fn rv64uf_v_fadd      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fadd".to_string(), false),  1); }
-#[test]fn rv64uf_v_fclass    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fclass".to_string(), false),  1); }
-#[test]fn rv64uf_v_fcmp      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcmp".to_string(), false),  1); }
-#[test]fn rv64uf_v_fcvt      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt".to_string(), false),  1); }
-#[test]fn rv64uf_v_fcvt_w    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt_w".to_string(), false),  1); }
-#[test]fn rv64uf_v_fdiv      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fdiv".to_string(), false),  1); }
-#[test]fn rv64uf_v_fmadd     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmadd".to_string(), false),  1); }
-#[test]fn rv64uf_v_fmin      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmin".to_string(), false),  1); }
+#[test]
+fn rv64uf_v_fadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fclass() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fclass".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fcmp() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcmp".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fcvt() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fcvt_w() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt_w".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fdiv() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fdiv".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fmadd() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmadd".to_string(),
+            false
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fmin() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmin".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64uf_v_ldst      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-ldst".to_string(), false),  1); }
 // #[test]fn rv64uf_v_move      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-move".to_string(), false),  1); }
 // #[test]fn rv64uf_v_recoding  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-recoding".to_string(), false),  1); }
 // #[test]fn rv64uf_v_structural() { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-structural".to_string(), false),  1); }
-
-
 
 // #[test]fn rv64ua_v_amoadd_d  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-amoadd_d".to_string(), false),  1); }
 // #[test]fn rv64ua_v_amoadd_w  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-amoadd_w".to_string(), false),  1); }
@@ -200,11 +1403,29 @@ extern crate dydra;
 // #[test]fn rv64ua_v_amoxor_w  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-amoxor_w".to_string(), false),  1); }
 // #[test]fn rv64ua_v_lrsc      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-lrsc".to_string(), false),  1); }
 // #[test]fn rv64uc_v_rvc       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uc-v-rvc".to_string(), false),  1); }
-#[test]fn rv64um_v_div       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-div".to_string(), false),  1); }
+#[test]
+fn rv64um_v_div() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-div".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_v_divu      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-divu".to_string(), false),  1); }
 // #[test]fn rv64um_v_divuw     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-divuw".to_string(), false),  1); }
 // #[test]fn rv64um_v_divw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-divw".to_string(), false),  1); }
-#[test]fn rv64um_v_mul       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mul".to_string(), false),  1); }
+#[test]
+fn rv64um_v_mul() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mul".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_v_mulh      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mulh".to_string(), false),  1); }
 // #[test]fn rv64um_v_mulhsu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mulhsu".to_string(), false),  1); }
 // #[test]fn rv64um_v_mulhu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mulhu".to_string(), false),  1); }
@@ -213,7 +1434,6 @@ extern crate dydra;
 // #[test]fn rv64um_v_remu      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-remu".to_string(), false),  1); }
 // #[test]fn rv64um_v_remuw     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-remuw".to_string(), false),  1); }
 // #[test]fn rv64um_v_remw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-remw".to_string(), false),  1); }
-
 
 // #[test]fn rv64ua_p_amoadd_d  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-amoadd_d".to_string(), false),  1); }
 // #[test]fn rv64ua_p_amoadd_w  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-amoadd_w".to_string(), false),  1); }
@@ -235,11 +1455,29 @@ extern crate dydra;
 // #[test]fn rv64ua_p_amoxor_w  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-amoxor_w".to_string(), false),  1); }
 // #[test]fn rv64ua_p_lrsc      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-lrsc".to_string(), false),  1); }
 // #[test]fn rv64uc_p_rvc       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uc-p-rvc".to_string(), false),  1); }
-#[test]fn rv64um_p_div       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-div".to_string(), false),  1); }
+#[test]
+fn rv64um_p_div() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-div".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_p_divu      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-divu".to_string(), false),  1); }
 // #[test]fn rv64um_p_divuw     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-divuw".to_string(), false),  1); }
 // #[test]fn rv64um_p_divw      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-divw".to_string(), false),  1); }
-#[test]fn rv64um_p_mul       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mul".to_string(), false),  1); }
+#[test]
+fn rv64um_p_mul() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mul".to_string(),
+            false
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_p_mulh      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mulh".to_string(), false),  1); }
 // #[test]fn rv64um_p_mulhsu    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mulhsu".to_string(), false),  1); }
 // #[test]fn rv64um_p_mulhu     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mulhu".to_string(), false),  1); }

--- a/tests/lib_step.rs
+++ b/tests/lib_step.rs
@@ -1,183 +1,1387 @@
 extern crate dydra;
 
-#[test]fn rv64ui_p_simple_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-simple".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_simple_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-simple".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_add_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add".to_string(), true),  1); }
-#[test]fn rv64ui_p_addi_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addi".to_string(), true),  1); }
-#[test]fn rv64ui_p_addiw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addiw".to_string(), true),  1); }
-#[test]fn rv64ui_p_addw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addw".to_string(), true),  1); }
-#[test]fn rv64ui_p_sub_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sub".to_string(), true),  1); }
-#[test]fn rv64ui_p_subw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-subw".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_add_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-add".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_addi_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addi".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_addiw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addiw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_addw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-addw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sub_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sub".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_subw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-subw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_and_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-and".to_string(), true),  1); }
-#[test]fn rv64ui_p_andi_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-andi".to_string(), true),  1); }
-#[test]fn rv64ui_p_or_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-or".to_string(), true),  1); }
-#[test]fn rv64ui_p_ori_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ori".to_string(), true),  1); }
-#[test]fn rv64ui_p_xor_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xor".to_string(), true),  1); }
-#[test]fn rv64ui_p_xori_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xori".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_and_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-and".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_andi_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-andi".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_or_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-or".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_ori_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ori".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_xor_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xor".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_xori_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-xori".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_auipc_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-auipc".to_string(), true),  1); }
-#[test]fn rv64ui_p_lui_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lui".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_auipc_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-auipc".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lui_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lui".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_beq_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-beq".to_string(), true),  1); }
-#[test]fn rv64ui_p_bge_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bge".to_string(), true),  1); }
-#[test]fn rv64ui_p_bgeu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bgeu".to_string(), true),  1); }
-#[test]fn rv64ui_p_blt_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-blt".to_string(), true),  1); }
-#[test]fn rv64ui_p_bltu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bltu".to_string(), true),  1); }
-#[test]fn rv64ui_p_bne_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bne".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_beq_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-beq".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bge_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bge".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bgeu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bgeu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_blt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-blt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bltu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bltu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_bne_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-bne".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_fence_i_step () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-fence_i".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_fence_i_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-fence_i".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_jal_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jal".to_string(), true),  1); }
-#[test]fn rv64ui_p_jalr_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jalr".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_jal_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jal".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_jalr_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-jalr".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_lb_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lb".to_string(), true),  1); }
-#[test]fn rv64ui_p_lbu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lbu".to_string(), true),  1); }
-#[test]fn rv64ui_p_ld_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ld".to_string(), true),  1); }
-#[test]fn rv64ui_p_lh_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lh".to_string(), true),  1); }
-#[test]fn rv64ui_p_lhu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lhu".to_string(), true),  1); }
-#[test]fn rv64ui_p_lw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lw".to_string(), true),  1); }
-#[test]fn rv64ui_p_lwu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lwu".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_lb_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lb".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lbu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lbu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_ld_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-ld".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lh_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lh".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lhu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lhu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_lwu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-lwu".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_sb_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sb".to_string(), true),  1); }
-#[test]fn rv64ui_p_sd_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sd".to_string(), true),  1); }
-#[test]fn rv64ui_p_sh_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sh".to_string(), true),  1); }
-#[test]fn rv64ui_p_sw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sw".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_sb_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sb".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sh_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sh".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_slt_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slt".to_string(), true),  1); }
-#[test]fn rv64ui_p_slti_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slti".to_string(), true),  1); }
-#[test]fn rv64ui_p_sltiu_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltiu".to_string(), true),  1); }
-#[test]fn rv64ui_p_sltu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltu".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_slt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_slti_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slti".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sltiu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltiu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sltu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sltu".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_sll_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sll".to_string(), true),  1); }
-#[test]fn rv64ui_p_slli_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slli".to_string(), true),  1); }
-#[test]fn rv64ui_p_slliw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slliw".to_string(), true),  1); }
-#[test]fn rv64ui_p_sllw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sllw".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_sll_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sll".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_slli_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slli".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_slliw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-slliw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sllw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sllw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_sra_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sra".to_string(), true),  1); }
-#[test]fn rv64ui_p_srai_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srai".to_string(), true),  1); }
-#[test]fn rv64ui_p_sraiw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraiw".to_string(), true),  1); }
-#[test]fn rv64ui_p_sraw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraw".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_sra_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sra".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srai_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srai".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sraiw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraiw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_sraw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-sraw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_p_srl_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srl".to_string(), true),  1); }
-#[test]fn rv64ui_p_srli_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srli".to_string(), true),  1); }
-#[test]fn rv64ui_p_srliw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srliw".to_string(), true),  1); }
-#[test]fn rv64ui_p_srlw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srlw".to_string(), true),  1); }
+#[test]
+fn rv64ui_p_srl_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srl".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srli_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srli".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srliw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srliw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_p_srlw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-p-srlw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ud_p_fadd_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fadd".to_string(), true),  1); }
-#[test]fn rv64ud_p_fclass_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fclass".to_string(), true),  1); }
-#[test]fn rv64ud_p_fcmp_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcmp".to_string(), true),  1); }
-#[test]fn rv64ud_p_fcvt_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt".to_string(), true),  1); }
-#[test]fn rv64ud_p_fcvt_w_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt_w".to_string(), true),  1); }
-#[test]fn rv64ud_p_fdiv_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fdiv".to_string(), true),  1); }
-#[test]fn rv64ud_p_fmadd_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmadd".to_string(), true),  1); }
-#[test]fn rv64ud_p_fmin_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmin".to_string(), true),  1); }
+#[test]
+fn rv64ud_p_fadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fclass_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fclass".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fcmp_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcmp".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fcvt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fcvt_w_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fcvt_w".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fdiv_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fdiv".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fmadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_p_fmin_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-fmin".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64ud_p_ldst_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-ldst".to_string(), true),  1); }
 // #[test]fn rv64ud_p_move_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-move".to_string(), true),  1); }
 // #[test]fn rv64ud_p_recoding_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-recoding".to_string(), true),  1); }
 // #[test]fn rv64ud_p_structural()_step { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-p-structural".to_string(), true),  1); }
 
-#[test]fn rv64uf_p_fadd_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fadd".to_string(), true),  1); }
-#[test]fn rv64uf_p_fclass_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fclass".to_string(), true),  1); }
-#[test]fn rv64uf_p_fcmp_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcmp".to_string(), true),  1); }
-#[test]fn rv64uf_p_fcvt_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt".to_string(), true),  1); }
-#[test]fn rv64uf_p_fcvt_w_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt_w".to_string(), true),  1); }
-#[test]fn rv64uf_p_fdiv_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fdiv".to_string(), true),  1); }
-#[test]fn rv64uf_p_fmadd_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmadd".to_string(), true),  1); }
-#[test]fn rv64uf_p_fmin_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmin".to_string(), true),  1); }
+#[test]
+fn rv64uf_p_fadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fclass_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fclass".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fcmp_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcmp".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fcvt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fcvt_w_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fcvt_w".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fdiv_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fdiv".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fmadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_p_fmin_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-fmin".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64uf_p_ldst_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-ldst".to_string(), true),  1); }
 // #[test]fn rv64uf_p_move_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-move".to_string(), true),  1); }
 // #[test]fn rv64uf_p_recoding_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-recoding".to_string(), true),  1); }
 // #[test]fn rv64uf_p_structural()_step { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-p-structural".to_string(), true),  1); }
 
-#[test]fn rv64ui_v_simple_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-simple".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_simple_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-simple".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_add_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-add".to_string(), true),  1); }
-#[test]fn rv64ui_v_addi_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addi".to_string(), true),  1); }
-#[test]fn rv64ui_v_addiw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addiw".to_string(), true),  1); }
-#[test]fn rv64ui_v_addw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addw".to_string(), true),  1); }
-#[test]fn rv64ui_v_sub_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sub".to_string(), true),  1); }
-#[test]fn rv64ui_v_subw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-subw".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_add_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-add".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_addi_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addi".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_addiw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addiw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_addw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-addw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sub_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sub".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_subw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-subw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_and_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-and".to_string(), true),  1); }
-#[test]fn rv64ui_v_andi_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-andi".to_string(), true),  1); }
-#[test]fn rv64ui_v_or_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-or".to_string(), true),  1); }
-#[test]fn rv64ui_v_ori_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ori".to_string(), true),  1); }
-#[test]fn rv64ui_v_xor_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xor".to_string(), true),  1); }
-#[test]fn rv64ui_v_xori_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xori".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_and_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-and".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_andi_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-andi".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_or_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-or".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_ori_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ori".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_xor_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xor".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_xori_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-xori".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_auipc_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-auipc".to_string(), true),  1); }
-#[test]fn rv64ui_v_lui_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lui".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_auipc_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-auipc".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lui_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lui".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_beq_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-beq".to_string(), true),  1); }
-#[test]fn rv64ui_v_bge_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bge".to_string(), true),  1); }
-#[test]fn rv64ui_v_bgeu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bgeu".to_string(), true),  1); }
-#[test]fn rv64ui_v_blt_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-blt".to_string(), true),  1); }
-#[test]fn rv64ui_v_bltu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bltu".to_string(), true),  1); }
-#[test]fn rv64ui_v_bne_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bne".to_string(), true),  1); }
-#[test]fn rv64ui_v_fence_i_step () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-fence_i".to_string(), true),  1); }
-#[test]fn rv64ui_v_jal_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jal".to_string(), true),  1); }
-#[test]fn rv64ui_v_jalr_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jalr".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_beq_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-beq".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bge_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bge".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bgeu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bgeu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_blt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-blt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bltu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bltu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_bne_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-bne".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_fence_i_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-fence_i".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_jal_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jal".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_jalr_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-jalr".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_lb_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lb".to_string(), true),  1); }
-#[test]fn rv64ui_v_lbu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lbu".to_string(), true),  1); }
-#[test]fn rv64ui_v_ld_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ld".to_string(), true),  1); }
-#[test]fn rv64ui_v_lh_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lh".to_string(), true),  1); }
-#[test]fn rv64ui_v_lhu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lhu".to_string(), true),  1); }
-#[test]fn rv64ui_v_lw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lw".to_string(), true),  1); }
-#[test]fn rv64ui_v_lwu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lwu".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_lb_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lb".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lbu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lbu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_ld_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-ld".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lh_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lh".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lhu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lhu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_lwu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-lwu".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_sb_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sb".to_string(), true),  1); }
-#[test]fn rv64ui_v_sd_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sd".to_string(), true),  1); }
-#[test]fn rv64ui_v_sh_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sh".to_string(), true),  1); }
-#[test]fn rv64ui_v_sw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sw".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_sb_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sb".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sh_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sh".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_slt_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slt".to_string(), true),  1); }
-#[test]fn rv64ui_v_slti_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slti".to_string(), true),  1); }
-#[test]fn rv64ui_v_sltiu_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltiu".to_string(), true),  1); }
-#[test]fn rv64ui_v_sltu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltu".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_slt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_slti_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slti".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sltiu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltiu".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sltu_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sltu".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_sll_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sll".to_string(), true),  1); }
-#[test]fn rv64ui_v_slli_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slli".to_string(), true),  1); }
-#[test]fn rv64ui_v_slliw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slliw".to_string(), true),  1); }
-#[test]fn rv64ui_v_sllw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sllw".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_sll_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sll".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_slli_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slli".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_slliw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-slliw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sllw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sllw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_sra_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sra".to_string(), true),  1); }
-#[test]fn rv64ui_v_srai_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srai".to_string(), true),  1); }
-#[test]fn rv64ui_v_sraiw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraiw".to_string(), true),  1); }
-#[test]fn rv64ui_v_sraw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraw".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_sra_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sra".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srai_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srai".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sraiw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraiw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_sraw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-sraw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ui_v_srl_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srl".to_string(), true),  1); }
-#[test]fn rv64ui_v_srli_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srli".to_string(), true),  1); }
-#[test]fn rv64ui_v_srliw_step   () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srliw".to_string(), true),  1); }
-#[test]fn rv64ui_v_srlw_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srlw".to_string(), true),  1); }
+#[test]
+fn rv64ui_v_srl_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srl".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srli_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srli".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srliw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srliw".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ui_v_srlw_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ui-v-srlw".to_string(),
+            true
+        ),
+        1
+    );
+}
 
-#[test]fn rv64ud_v_fadd_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fadd".to_string(), true),  1); }
-#[test]fn rv64ud_v_fclass_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fclass".to_string(), true),  1); }
-#[test]fn rv64ud_v_fcmp_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcmp".to_string(), true),  1); }
-#[test]fn rv64ud_v_fcvt_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt".to_string(), true),  1); }
-#[test]fn rv64ud_v_fcvt_w_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt_w".to_string(), true),  1); }
-#[test]fn rv64ud_v_fdiv_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fdiv".to_string(), true),  1); }
-#[test]fn rv64ud_v_fmadd_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmadd".to_string(), true),  1); }
-#[test]fn rv64ud_v_fmin_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmin".to_string(), true),  1); }
+#[test]
+fn rv64ud_v_fadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fclass_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fclass".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fcmp_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcmp".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fcvt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fcvt_w_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fcvt_w".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fdiv_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fdiv".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fmadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64ud_v_fmin_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-fmin".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64ud_v_ldst_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-ldst".to_string(), true),  1); }
 // #[test]fn rv64ud_v_move_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-move".to_string(), true),  1); }
 // #[test]fn rv64ud_v_recoding_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-recoding".to_string(), true),  1); }
 // #[test]fn rv64ud_v_structural()_step { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ud-v-structural".to_string(), true),  1); }
-#[test]fn rv64uf_v_fadd_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fadd".to_string(), true),  1); }
-#[test]fn rv64uf_v_fclass_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fclass".to_string(), true),  1); }
-#[test]fn rv64uf_v_fcmp_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcmp".to_string(), true),  1); }
-#[test]fn rv64uf_v_fcvt_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt".to_string(), true),  1); }
-#[test]fn rv64uf_v_fcvt_w_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt_w".to_string(), true),  1); }
-#[test]fn rv64uf_v_fdiv_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fdiv".to_string(), true),  1); }
-#[test]fn rv64uf_v_fmadd_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmadd".to_string(), true),  1); }
-#[test]fn rv64uf_v_fmin_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmin".to_string(), true),  1); }
+#[test]
+fn rv64uf_v_fadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fclass_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fclass".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fcmp_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcmp".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fcvt_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fcvt_w_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fcvt_w".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fdiv_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fdiv".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fmadd_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmadd".to_string(),
+            true
+        ),
+        1
+    );
+}
+#[test]
+fn rv64uf_v_fmin_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-fmin".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64uf_v_ldst_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-ldst".to_string(), true),  1); }
 // #[test]fn rv64uf_v_move_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-move".to_string(), true),  1); }
 // #[test]fn rv64uf_v_recoding_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-recoding".to_string(), true),  1); }
 // #[test]fn rv64uf_v_structural()_step { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uf-v-structural".to_string(), true),  1); }
-
-
 
 // #[test]fn rv64ua_v_amoadd_d_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-amoadd_d".to_string(), true),  1); }
 // #[test]fn rv64ua_v_amoadd_w_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-amoadd_w".to_string(), true),  1); }
@@ -199,11 +1403,29 @@ extern crate dydra;
 // #[test]fn rv64ua_v_amoxor_w_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-amoxor_w".to_string(), true),  1); }
 // #[test]fn rv64ua_v_lrsc_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-v-lrsc".to_string(), true),  1); }
 // #[test]fn rv64uc_v_rvc_step       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uc-v-rvc".to_string(), true),  1); }
-#[test]fn rv64um_v_div_step       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-div".to_string(), true),  1); }
+#[test]
+fn rv64um_v_div_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-div".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_v_divu_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-divu".to_string(), true),  1); }
 // #[test]fn rv64um_v_divuw_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-divuw".to_string(), true),  1); }
 // #[test]fn rv64um_v_divw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-divw".to_string(), true),  1); }
-#[test]fn rv64um_v_mul_step       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mul".to_string(), true),  1); }
+#[test]
+fn rv64um_v_mul_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mul".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_v_mulh_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mulh".to_string(), true),  1); }
 // #[test]fn rv64um_v_mulhsu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mulhsu".to_string(), true),  1); }
 // #[test]fn rv64um_v_mulhu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-mulhu".to_string(), true),  1); }
@@ -212,7 +1434,6 @@ extern crate dydra;
 // #[test]fn rv64um_v_remu_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-remu".to_string(), true),  1); }
 // #[test]fn rv64um_v_remuw_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-remuw".to_string(), true),  1); }
 // #[test]fn rv64um_v_remw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-v-remw".to_string(), true),  1); }
-
 
 // #[test]fn rv64ua_p_amoadd_d_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-amoadd_d".to_string(), true),  1); }
 // #[test]fn rv64ua_p_amoadd_w_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-amoadd_w".to_string(), true),  1); }
@@ -234,11 +1455,29 @@ extern crate dydra;
 // #[test]fn rv64ua_p_amoxor_w_step  () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-amoxor_w".to_string(), true),  1); }
 // #[test]fn rv64ua_p_lrsc_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64ua-p-lrsc".to_string(), true),  1); }
 // #[test]fn rv64uc_p_rvc_step       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64uc-p-rvc".to_string(), true),  1); }
-#[test]fn rv64um_p_div_step       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-div".to_string(), true),  1); }
+#[test]
+fn rv64um_p_div_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-div".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_p_divu_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-divu".to_string(), true),  1); }
 // #[test]fn rv64um_p_divuw_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-divuw".to_string(), true),  1); }
 // #[test]fn rv64um_p_divw_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-divw".to_string(), true),  1); }
-#[test]fn rv64um_p_mul_step       () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mul".to_string(), true),  1); }
+#[test]
+fn rv64um_p_mul_step() {
+    assert_eq!(
+        dydra::run_riscv_test(
+            "/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mul".to_string(),
+            true
+        ),
+        1
+    );
+}
 // #[test]fn rv64um_p_mulh_step      () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mulh".to_string(), true),  1); }
 // #[test]fn rv64um_p_mulhsu_step    () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mulhsu".to_string(), true),  1); }
 // #[test]fn rv64um_p_mulhu_step     () { assert_eq!(dydra::run_riscv_test("/riscv64-unknown-elf/share/riscv-tests/isa/rv64um-p-mulhu".to_string(), true),  1); }


### PR DESCRIPTION
This patch ran `cargo fix` and fixed the format automatically.
It also enabled format check on github action.